### PR TITLE
Split documentation into chapters and draft introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# MySQL Naming Conventions Guide
+
+This repository hosts a step-by-step guide that explains how to name MySQL database objects in a way that scales for large teams. The material is organised as standalone chapters so readers can move between topics just like browsing a W3Schools tutorial.
+
+## How to Navigate
+
+1. Start with the [documentation index](docs/index.md). It contains the complete table of contents and links to every chapter.
+2. Read one chapter at a time. Each chapter focuses on a single topic and explains the rule, the problems it prevents, and practical examples.
+3. Revisit chapters as needed. They are written in simple English so engineers, analysts, and reviewers share the same understanding.
+
+> _Note_: Only the first chapter is available right now. Additional chapters will be published in future commits so that each addition can be reviewed carefully.

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -1,0 +1,96 @@
+# Chapter 1 – Introduction
+
+[← Back to index](index.md) • Next chapter: Core Naming Rules (coming soon)
+
+---
+
+This opening chapter explains why naming rules matter for MySQL, the common problems that appear when teams ignore them, and the goals that guide the rest of the standard. The tone is practical and the language is simple so everyone on the team can follow along.
+
+## 1.1 Why Naming Conventions Matter in Scalable MySQL Projects
+
+### The challenge
+MySQL lets you name databases, tables, and columns however you want. That freedom sounds helpful, but it creates chaos when different people make different choices. Over time the schema becomes unpredictable, which slows down product work.
+
+### The recommended practice
+Agree on a single naming playbook before you create or change any schema objects. Document it, share it, and review code against it. When every table follows the same pattern, teammates can read each other's work without guessing intent.
+
+### What goes wrong without it
+- Automation scripts fail because they cannot guess which column contains the data they need.
+- Reviewers spend time asking for explanations instead of checking business logic.
+- Integrations break silently when two tables use similar names for different ideas.
+
+### Example
+```sql
+-- Without a shared convention
+SELECT *
+FROM Customers c
+JOIN CUSTOMERDETAILS cd ON c.CustID = cd.CustomerID;
+
+-- With an agreed convention
+SELECT c.id, c.full_name, cp.locale
+FROM customer c
+JOIN customer_profile cp ON c.id = cp.customer_id;
+```
+The second query is shorter, easier to scan, and obvious about the relationships.
+
+> **Field Note:** A naming guide is not about control. It keeps the team fast by removing the daily friction of decoding someone else's style.
+
+## 1.2 Common Pain Points in Poorly Named Schemas
+
+### The challenge
+When names drift, engineers, analysts, and data pipelines are forced to translate meaning manually. This creates bugs and increases cognitive load.
+
+### Warning signs to watch for
+- **Duplicate concepts:** `order`, `orders`, and `tbl_order` all refer to the same entity.
+- **Mystery columns:** `flag1` or `data_1` hide the real purpose of the field.
+- **Changing names:** API consumers break when a column changes from `UserID` to `user_id` without notice.
+- **Unclear relationships:** Foreign keys named `ref1` or `fk_user` do not show which tables they connect.
+
+### Example
+```sql
+-- Hard to understand
+SELECT flag1
+FROM tbl_order
+WHERE status_f = 'A';
+
+-- Clear and predictable
+SELECT is_expedited
+FROM `order`
+WHERE status = 'approved';
+```
+The clear version uses real words. Anyone can explain what it does without asking the original author.
+
+> **Field Note:** Confusing names slow down onboarding. New teammates need weeks to learn the hidden language before they can contribute.
+
+## 1.3 Goals of This Standard (Consistency, Clarity, Scalability, Lintability)
+
+### The four pillars
+1. **Consistency:** Similar things look the same everywhere in the schema. Reviewers can spot mistakes immediately.
+2. **Clarity:** Names describe the actual business meaning. No mental translation is required.
+3. **Scalability:** The rules keep working when you add more services, more data, and more people.
+4. **Lintability:** Automated checks can verify the rules, which prevents regressions during fast releases.
+
+### How the pillars work together
+- Consistency unlocks clarity because everyone recognises common patterns.
+- Clarity supports scalability because downstream tools can rely on predictable names.
+- Lintability protects both consistency and clarity by catching bad names before they land in production.
+
+### Practical example
+```text
+Good: payment_transaction
+- Consistent: uses lower_snake_case
+- Clear: joins two business words
+- Scalable: leaves room for related tables like payment_receipt
+- Lintable: a rule can check the pattern automatically
+
+Bad: payTrxTbl
+- Inconsistent casing and abbreviations
+- Unclear purpose
+- Hard to validate with tooling
+```
+
+> **Field Note:** The pillars act like a checklist during reviews. If a proposed name fails any one of them, the team should pause and fix it before merging.
+
+---
+
+[← Back to index](index.md) • Next chapter: Core Naming Rules (coming soon)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+# MySQL Naming Conventions Guide · Index
+
+Welcome! This index mirrors the table of contents for the complete guide. Every chapter lives in its own Markdown file so you can focus on one topic at a time, similar to how W3Schools breaks lessons into short pages.
+
+## Available Chapters
+
+- [Chapter 1 – Introduction](01-introduction.md)
+
+## Coming Soon
+
+The remaining topics from the project outline will be published gradually so each one can be reviewed in depth:
+
+2. Core Naming Rules  
+3. Database-Level Conventions  
+4. Table & Column Naming  
+5. Constraints & Indexes  
+6. Views, Routines & Triggers  
+7. Migrations & Versioning  
+8. Additional Conventions That Pay Off at Scale  
+9. Examples & Patterns in Action  
+10. Cheat Sheet (Quick Reference)  
+11. Conclusion
+
+Subscribe to the repository or check back after each commit to follow the progress chapter by chapter.


### PR DESCRIPTION
## Summary
- restructure the guide into standalone chapter files with the root README linking to the documentation index
- add a documentation index page that mirrors the project table of contents and highlights remaining chapters to come
- author Chapter 1 (Introduction) with detailed sections on importance, pain points, and goals written in simple English

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d8d4f5b5c48332b4b468c5ec32acfe