### PR TITLE
Rewrite MySQL naming guide documentation with consistent examples

### DIFF
--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -4,92 +4,63 @@
 
 ---
 
-This opening chapter explains why naming rules matter for MySQL, the common problems that appear when teams ignore them, and the goals that guide the rest of the standard. The tone is practical and the language is simple so everyone on the team can follow along.
+Think of this guide as a W3Schools-style course for naming things in MySQL. We keep the lessons short, show the rules, and immediately follow with examples you can copy.
 
-## 1.1 Why Naming Conventions Matter in Scalable MySQL Projects
+## 1.1 Why bother with naming rules?
 
-### The challenge
-MySQL lets you name databases, tables, and columns however you want. That freedom sounds helpful, but it creates chaos when different people make different choices. Over time the schema becomes unpredictable, which slows down product work.
+**The problem.** MySQL lets every engineer pick their own style. After a few releases, your schema turns into a puzzle of mixed cases, unexplained acronyms, and duplicated ideas.
 
-### The recommended practice
-Agree on a single naming playbook before you create or change any schema objects. Document it, share it, and review code against it. When every table follows the same pattern, teammates can read each other's work without guessing intent.
+**The payoff.** A shared convention removes the guesswork. When every table and column follows the same pattern, you can read new SQL like plain English, reviewers move faster, and automation scripts stop breaking.
 
-### What goes wrong without it
-- Automation scripts fail because they cannot guess which column contains the data they need.
-- Reviewers spend time asking for explanations instead of checking business logic.
-- Integrations break silently when two tables use similar names for different ideas.
+**Quick look.**
 
-### Example
 ```sql
--- Without a shared convention
+-- Random styles slow everyone down
 SELECT *
-FROM Customers c
-JOIN CUSTOMERDETAILS cd ON c.CustID = cd.CustomerID;
+FROM Projects
+JOIN projectMembers ON Projects.ID = projectMembers.projectID;
 
--- With an agreed convention
-SELECT c.id, c.full_name, cp.locale
-FROM customer c
-JOIN customer_profile cp ON c.id = cp.customer_id;
+-- Consistent names read like a sentence
+SELECT p.id, p.name, tm.full_name
+FROM project p
+JOIN project_member tm ON tm.project_id = p.id;
 ```
-The second query is shorter, easier to scan, and obvious about the relationships.
 
-> **Field Note:** A naming guide is not about control. It keeps the team fast by removing the daily friction of decoding someone else's style.
+> **Remember:** you only choose a name once, but the team reads it hundreds of times.
 
-## 1.2 Common Pain Points in Poorly Named Schemas
+## 1.2 What goes wrong without a standard?
 
-### The challenge
-When names drift, engineers, analysts, and data pipelines are forced to translate meaning manually. This creates bugs and increases cognitive load.
+Follow this checklist. If any item matches your schema today, you will benefit from the rules in this guide.
 
-### Warning signs to watch for
-- **Duplicate concepts:** `order`, `orders`, and `tbl_order` all refer to the same entity.
-- **Mystery columns:** `flag1` or `data_1` hide the real purpose of the field.
-- **Changing names:** API consumers break when a column changes from `UserID` to `user_id` without notice.
-- **Unclear relationships:** Foreign keys named `ref1` or `fk_user` do not show which tables they connect.
+1. **Duplicate words.** `project`, `projects`, and `tbl_project` all exist at once.
+2. **Mystery flags.** Columns called `flag_a` or `data1` force guesswork.
+3. **Inconsistent casing.** `TaskID` in one table, `task_id` in another.
+4. **Hidden relationships.** Foreign keys named `ref1` give no hint about the target table.
 
-### Example
+Here is the difference in practice:
+
 ```sql
--- Hard to understand
-SELECT flag1
-FROM tbl_order
-WHERE status_f = 'A';
+-- Painful to read
+SELECT flag_a
+FROM tbl_project_record
+WHERE stat = 'A';
 
--- Clear and predictable
-SELECT is_expedited
-FROM `order`
-WHERE status = 'approved';
-```
-The clear version uses real words. Anyone can explain what it does without asking the original author.
-
-> **Field Note:** Confusing names slow down onboarding. New teammates need weeks to learn the hidden language before they can contribute.
-
-## 1.3 Goals of This Standard (Consistency, Clarity, Scalability, Lintability)
-
-### The four pillars
-1. **Consistency:** Similar things look the same everywhere in the schema. Reviewers can spot mistakes immediately.
-2. **Clarity:** Names describe the actual business meaning. No mental translation is required.
-3. **Scalability:** The rules keep working when you add more services, more data, and more people.
-4. **Lintability:** Automated checks can verify the rules, which prevents regressions during fast releases.
-
-### How the pillars work together
-- Consistency unlocks clarity because everyone recognises common patterns.
-- Clarity supports scalability because downstream tools can rely on predictable names.
-- Lintability protects both consistency and clarity by catching bad names before they land in production.
-
-### Practical example
-```text
-Good: payment_transaction
-- Consistent: uses lower_snake_case
-- Clear: joins two business words
-- Scalable: leaves room for related tables like payment_receipt
-- Lintable: a rule can check the pattern automatically
-
-Bad: payTrxTbl
-- Inconsistent casing and abbreviations
-- Unclear purpose
-- Hard to validate with tooling
+-- Straightforward to read
+SELECT is_archived
+FROM project_record
+WHERE status_code = 'active';
 ```
 
-> **Field Note:** The pillars act like a checklist during reviews. If a proposed name fails any one of them, the team should pause and fix it before merging.
+## 1.3 How to use this guide
+
+Each chapter follows the same structure:
+
+1. **Explain the rule** in clear English.
+2. **Show why it matters** with short bullet points.
+3. **Demonstrate the rule** using a small project-tracking schema (tables such as `project`, `team_member`, and `time_entry`).
+4. **Give you a quick checklist** so you can apply the idea immediately.
+
+If you are onboarding a teammate, send them this chapter and the cheat sheet (Chapter 10). If you are reviewing code, open the relevant chapter while you check the migration.
 
 ---
 

--- a/docs/02-core-naming-rules.md
+++ b/docs/02-core-naming-rules.md
@@ -2,206 +2,190 @@
 
 [← Previous: Introduction](01-introduction.md) • [Back to index](index.md) • [Next chapter →](03-database-level-conventions.md)
 
-This chapter explains the everyday rules that keep a MySQL schema readable. Each rule is written in simple English, but the ideas go deep so your team can apply them with confidence.
+This chapter is the heart of the guide. Each section follows a W3Schools rhythm: learn the rule, see why it matters, then copy a working example. All examples use a simple project-tracking schema (`project`, `team_member`, `time_entry`) so the patterns stay consistent throughout the guide.
 
-## 2.1 Case & Style → Why lower_snake_case Wins
+## 2.1 Use `lower_snake_case` everywhere
 
-**Rule.** Write every database name, table name, column name, index name, and routine name in `lower_snake_case`.
+**Rule.** Write every identifier—databases, tables, columns, indexes, routines—in lowercase snake case.
 
-**Why this matters.**
-- MySQL is case-sensitive on some operating systems. Using a single style removes "works on my machine" bugs.
-- Snake case keeps multiword names readable without guessing where one word ends.
-- Lowercase avoids mixed-case typos, especially when people copy names into shell scripts or config files.
+**Why it matters.**
 
-**What goes wrong without the rule.**
-- `CustomerOrders` may be stored as `customerorders` on Linux but not on macOS, causing migrations to fail in production.
-- `UserID` and `userId` look similar yet MySQL treats them as different identifiers in case-sensitive setups, leading to duplicates.
-- Query builders and ORMs often default to lowercase table names. Mixing cases forces awkward overrides in every service.
+- MySQL treats names differently on Linux versus Windows. One style avoids "works on my machine" bugs.
+- Snake case keeps multi-word names readable without quoting.
+- Lowercase names integrate smoothly with ORMs, CLI tools, and environment variables.
 
-**How to apply it.**
-- Convert every word to lowercase and join with underscores: `customer_order_items`.
-- Avoid hyphens (`-`) because they require quoting and can be mistaken for subtraction.
-- Use consistent pluralization rules (see Section 2.4 for table names).
+**How to apply.**
 
-**Quick example.**
+1. Convert each word to lowercase.
+2. Join the words with underscores.
+3. Avoid hyphens or spaces because they force backticks.
+
 ```sql
--- Good
-SELECT order_total FROM customer_orders WHERE customer_id = 42;
+-- ✅ Follows the rule
+SELECT total_minutes
+FROM time_entry
+WHERE project_id = 12;
 
--- Risky: camelCase and hyphenated names require quoting and may break tools
-SELECT `orderTotal` FROM `Customer-Orders` WHERE `CustomerID` = 42;
+-- ❌ Breaks the rule (camelCase and mixed case table)
+SELECT TotalMinutes
+FROM TimeEntry
+WHERE ProjectID = 12;
 ```
 
-## 2.2 Language → Why Full Words Beat Abbreviations
+## 2.2 Prefer full words over cryptic abbreviations
 
-**Rule.** Use full, descriptive words in names instead of shorthand.
+**Rule.** Spell out business terms. Use abbreviations only when the whole team knows the meaning (such as `id`, `ip`, `url`).
 
-**Why this matters.**
-- Future teammates or auditors may not know your internal acronyms.
-- Full words make search across the codebase easier (`shipping_address` matches plain English).
-- You write names once but read them hundreds of times. Saving one or two characters is not worth the confusion.
+**Why it matters.**
 
-**What goes wrong without the rule.**
-- `cust_addr` leaves new engineers guessing whether the column holds billing or shipping data.
-- Abbreviations drift over time: one team uses `amt`, another uses `amount`, and joins become harder to read.
-- External partners cannot map unclear column names to their API fields, causing integration delays.
+- Full names are self-documenting and search-friendly.
+- New teammates understand the schema without a translation guide.
+- Analytics tools and dashboards show useful labels automatically.
 
-**How to apply it.**
-- Spell out domain concepts: `expiration_date`, `tracking_number`, `discount_percentage`.
-- If the term is truly long, create a glossary entry in the documentation so everyone uses the same word.
-- Only shorten words that are universally understood (e.g., `id`, `url`, `ip`).
+**How to apply.**
 
-**Quick example.**
+1. Write the real-world phrase: `billing_address`, not `bill_addr`.
+2. If the word feels long, add it to a glossary so the team stays aligned.
+3. Be consistent. If you pick `due_date`, use it everywhere (not `deadline` in one table and `due` in another).
+
 ```sql
--- Good: the meaning is clear to anyone reading the schema
-ALTER TABLE invoice_payments ADD COLUMN payment_reference TEXT NOT NULL;
+-- ✅ Clear intent
+ALTER TABLE project
+    ADD COLUMN kickoff_date DATE NOT NULL;
 
--- Risky: "ref" and "amt" require prior tribal knowledge
-ALTER TABLE inv_pay ADD COLUMN pay_ref TEXT NOT NULL;
+-- ❌ Requires tribal knowledge
+ALTER TABLE proj
+    ADD COLUMN kd DATE NOT NULL;
 ```
 
-## 2.3 Acronyms & Abbreviations → How to Use Them When Necessary
+## 2.3 Handle acronyms deliberately
 
-**Rule.** When you must use an acronym, keep it consistent, uppercase the letters inside the snake case, and document its meaning once.
+**Rule.** When an acronym is unavoidable (for example, `API`, `SKU`, `VAT`), write it in lowercase inside the snake case and document it once.
 
-**Why this matters.**
-- Some acronyms (such as `VAT`, `SKU`, `API`) are industry standards, and using them keeps names short yet clear.
-- Consistent formatting (`vat_rate`, `api_client_id`) prevents the same acronym from appearing as `Vat` in one place and `VAT` in another.
-- Documented acronyms reduce onboarding time and ensure code search returns all related objects.
+**Why it matters.**
 
-**What goes wrong without the rule.**
-- `vat`, `Vat`, and `value_added_tax` may all exist in one schema, forcing developers to guess which column to join.
-- Undocumented short forms (for example, `prc` for price) break analytics queries and BI dashboards that expect human-readable names.
-- Mixed casing (like `Sku` vs `SKU`) triggers false negatives in grep searches and leads to duplicate columns during migrations.
+- Consistent casing keeps search results reliable (`vat_rate`, not `VatRate`).
+- Documented acronyms reduce onboarding time.
+- Avoiding random uppercase letters prevents quoting issues.
 
-**How to apply it.**
-- Treat the acronym as a single word inside the snake case: `vat_number`, `api_key`.
-- Record every approved acronym in a `docs/glossary.md` (create one if it does not exist yet).
-- If two acronyms collide (`id` vs `invoice_id`), prefer the longer but clearer name.
+**How to apply.**
 
-**Quick example.**
+1. Treat the acronym as a regular word: `api_client_id`, `vat_rate`.
+2. Add a short description to your team glossary.
+3. If two acronyms collide (`id` vs `team_id`), keep both words for clarity.
+
 ```sql
--- Good: consistent style with documented acronyms
-CREATE TABLE inventory_items (
+-- ✅ Balanced use of acronyms
+CREATE TABLE integration_endpoint (
     id BIGINT UNSIGNED PRIMARY KEY,
-    sku VARCHAR(64) NOT NULL,
+    api_key CHAR(36) NOT NULL,
     vat_rate DECIMAL(5,2) NOT NULL
 );
 
--- Risky: inconsistent casing and unexplained shorthand
-CREATE TABLE inventory (
+-- ❌ Mixed casing and unexplained short forms
+CREATE TABLE integration (
     ID BIGINT PRIMARY KEY,
-    SkuCode VARCHAR(64) NOT NULL,
+    ApiKey CHAR(36) NOT NULL,
     v_rate DECIMAL(5,2) NOT NULL
 );
 ```
 
-## 2.4 Singular vs Plural Table Names → Why Singular Is Less Ambiguous
+## 2.4 Keep table names singular
 
-**Rule.** Name tables with singular nouns (`customer`, `order_item`) while keeping columns plural only when they store collections (such as JSON arrays).
+**Rule.** Name tables with singular nouns (`project`, `project_member`) so each row reads like one entity.
 
-**Why this matters.**
-- A table represents the concept of one entity. Singular names match how we talk about rows: "this order" rather than "this orders".
-- Singular names make joins read like sentences: `order JOIN customer ON order.customer_id = customer.id`.
-- ORMs and code generators often assume singular table names when deriving class names.
+**Why it matters.**
 
-**What goes wrong without the rule.**
-- Mixed pluralization (`users` table joined to `order_item`) produces awkward SQL and confuses naming in model classes.
-- English irregular plurals (`person` vs `people`) create mistakes in migrations and API responses.
-- BI tools auto-generate field names by singularizing. If the table is already plural, the tool guesses wrong (`statuss`).
+- Joins sound natural: `project JOIN project_member` instead of `projects JOIN project_members`.
+- Singular words avoid awkward plural forms (`person` vs `people`).
+- ORMs and scaffolding tools usually expect singular table names.
 
-**How to apply it.**
-- Use the domain noun in singular form: `invoice`, `invoice_payment`, `shipment_event`.
-- For join tables, combine the two singular nouns alphabetically: `order_product` instead of `orders_products`.
-- Document any intentional exception (such as `analytics` for a pre-aggregated table) so future maintainers know it is special.
+**How to apply.**
 
-**Quick example.**
+1. Use the entity name in singular form: `task`, `task_note`.
+2. For link tables, combine the two nouns alphabetically: `project_task` (not `task_project`).
+3. Document intentional exceptions such as `analytics` or `settings` so nobody "fixes" them later.
+
 ```sql
--- Good: joins read naturally
-SELECT customer.name, order_total.amount
-FROM customer
-JOIN order_total ON order_total.customer_id = customer.id;
+-- ✅ Reads cleanly
+SELECT p.name, tm.full_name
+FROM project p
+JOIN project_member tm ON tm.project_id = p.id;
 
--- Risky: mixed pluralization makes the query harder to read
-SELECT customers.name, orders_totals.amount
-FROM customers
-JOIN orders_totals ON orders_totals.customer_id = customers.id;
+-- ❌ Harder to parse
+SELECT projects.name, team_members.full_name
+FROM projects
+JOIN team_members ON team_members.project_id = projects.id;
 ```
 
-## 2.5 Avoiding Noise Prefixes (tbl_, col_) → Why They Harm More Than Help
+## 2.5 Skip noise prefixes like `tbl_` and `col_`
 
-**Rule.** Do not prefix table names with `tbl_` or column names with `col_`. Use the object name itself to show what it is.
+**Rule.** The object type is already obvious. Keep the meaningful word front and centre.
 
-**Why this matters.**
-- Schema objects already tell you their type: MySQL knows `customer` is a table, so `tbl_customer` repeats information.
-- Noise prefixes make names longer and harder to scan in diagrams or queries.
-- Removing prefixes later is painful because every application query must be updated.
+**Why it matters.**
 
-**What goes wrong without the rule.**
-- Developers forget the prefix and create both `tbl_order` and `order`, causing duplicated data structures.
-- BI tools that alphabetically list tables will group all `tbl_...` together, hiding related tables from quick view.
-- Prefix-heavy names hide meaningful words when truncated in dashboards or logs.
+- `tbl_project` wastes space and hides the actual topic.
+- Renaming later requires touching every query.
+- Dashboards and schema explorers sort alphabetically, so noise prefixes group unrelated tables together.
 
-**How to apply it.**
-- Name the table for the entity (`payment_method`) and the column for the attribute (`expiration_month`).
-- Use suffixes only when they add meaning (for example, `_history`, `_archive`, `_log`).
-- Review new migrations during code review to block regressions.
+**How to apply.**
 
-**Quick example.**
+1. Name tables by subject (`project_status`).
+2. Name columns by attribute (`archived_at`).
+3. Reserve suffixes for useful context (`_history`, `_log`).
+
 ```sql
--- Good: no noise prefixes, meaning is obvious
-CREATE TABLE payment_method (
-    id BIGINT UNSIGNED PRIMARY KEY,
-    customer_id BIGINT UNSIGNED NOT NULL,
-    card_last_four CHAR(4) NOT NULL
+-- ✅ Focused names
+CREATE TABLE project_status (
+    project_id BIGINT UNSIGNED PRIMARY KEY,
+    status_code VARCHAR(32) NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- Risky: prefixes make the schema harder to maintain
-CREATE TABLE tbl_payment_method (
-    col_id BIGINT UNSIGNED PRIMARY KEY,
-    col_customer_id BIGINT UNSIGNED NOT NULL,
-    col_card_last_four CHAR(4) NOT NULL
+-- ❌ Noise everywhere
+CREATE TABLE tbl_project_status (
+    col_project_id BIGINT UNSIGNED PRIMARY KEY,
+    col_status VARCHAR(32) NOT NULL,
+    col_updated TIMESTAMP NOT NULL
 );
 ```
 
-## 2.6 Reserved Words → Why They Create Long-Term Bugs
+## 2.6 Avoid reserved words and MySQL keywords
 
-**Rule.** Never use MySQL reserved words or SQL keywords as identifiers unless they are suffixed or prefixed with another word.
+**Rule.** Never use a reserved word alone (`order`, `group`, `select`). If you truly need the word, add context.
 
-**Why this matters.**
-- Reserved words like `order`, `select`, and `group` require backticks every time you query them.
-- Backticks hide bugs in application code because linters and editors cannot easily detect mis-typed keywords.
-- Upgrading MySQL can add new keywords, turning a previously "safe" name into a breaking change.
+**Why it matters.**
 
-**What goes wrong without the rule.**
-- An `order` table forces every query to be written as ``SELECT * FROM `order`;``. Forgetting the backticks causes syntax errors in production.
-- ORMs may silently rename or escape reserved words differently, creating inconsistent migrations across services.
-- Reserved names collide with other systems (for example, a REST API expecting `/orders` while the table is `` `order` ``).
+- Reserved words require backticks in every query.
+- New MySQL versions can add keywords and break your schema.
+- Many tools refuse to generate code for reserved names.
 
-**How to apply it.**
-- Check MySQL's official reserved word list before naming tables or columns. When in doubt, append a clarifying word: `customer_order`, `status_code`.
-- Add linting to migrations (using tools like `sqlfluff` or custom scripts) to block reserved words during code review.
-- Keep a shared glossary of approved names so new tables reuse proven, safe words.
+**How to apply.**
 
-**Quick example.**
+1. Check the official MySQL reserved word list before naming.
+2. Add a meaningful suffix or prefix: `purchase_order`, `status_code`.
+3. Lint migrations with tooling (`sqlfluff`, `schemalint`) to catch mistakes early.
+
 ```sql
--- Good: avoids the reserved word by adding context
-CREATE TABLE customer_order (
+-- ✅ Safe alternative
+CREATE TABLE purchase_order (
     id BIGINT UNSIGNED PRIMARY KEY,
-    customer_id BIGINT UNSIGNED NOT NULL,
-    status_code VARCHAR(32) NOT NULL
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
--- Risky: requires quoting forever and may break tooling
+-- ❌ Needs quoting forever
 CREATE TABLE `order` (
-    `id` BIGINT UNSIGNED PRIMARY KEY,
-    `customer_id` BIGINT UNSIGNED NOT NULL,
-    `status` VARCHAR(32) NOT NULL
+    `id` BIGINT UNSIGNED PRIMARY KEY
 );
 ```
 
-> **Field Note:** Revisit these rules whenever you design a new schema. Consistency at this level prevents painful refactors later.
+**Quick checklist before you name anything**
 
----
+- [ ] Is it lower_snake_case?
+- [ ] Are the words spelled out?
+- [ ] Are acronyms documented and lowercase?
+- [ ] Is the table name singular?
+- [ ] Are there any pointless prefixes?
+- [ ] Did you avoid reserved words?
 
-[← Previous: Introduction](01-introduction.md) • [Back to index](index.md) • [Next chapter →](03-database-level-conventions.md)
+Tick every box and you are ready for the next chapter.

--- a/docs/03-database-level-conventions.md
+++ b/docs/03-database-level-conventions.md
@@ -2,108 +2,89 @@
 
 [← Previous: Core Naming Rules](02-core-naming-rules.md) • [Back to index](index.md) • [Next chapter →](04-table-and-column-naming.md)
 
-This chapter focuses on the database names themselves. Before you create tables, you should decide how to label each database so every tool, environment, and teammate understands its purpose at a glance.
+Before you create tables, choose good names for the databases themselves. This chapter walks you through three simple patterns, each with a short checklist and an example you can copy into MySQL.
 
-## 3.1 Naming Databases by Product and Context
+## 3.1 Name databases by product and purpose
 
-**Rule.** Combine the product or bounded context with the primary function when naming a database. Example pattern: `<product>_<area>` such as `billing_service` or `analytics_reporting`.
+**Learn the rule.** Use the pattern `<product>_<purpose>`, for example `project_service` or `analytics_reporting`.
 
-**Why this matters.**
-- Readers know instantly which team owns the data and what problem the schema solves.
-- Infrastructure tools can apply permissions automatically based on predictable prefixes.
-- When a company has many services, descriptive database names prevent collisions.
+**Why it works.**
 
-**What goes wrong without the rule.**
-- Generic names like `db1` or `main` leave on-call engineers guessing which workload they are touching.
-- Security teams cannot scope access correctly because nothing in the name signals the business area.
-- Backups and restores take longer because operators must inspect the data before knowing which database to recover.
+- Every engineer instantly knows which team owns the data.
+- Permissions and monitoring can key off predictable prefixes.
+- Backups are easy to map to business areas.
 
-**How to apply it.**
-1. List the product, service, or bounded context (for example, `billing`, `support`, `identity`).
-2. Add a short word that explains the database role: `service`, `reporting`, `warehouse`, `archive`.
-3. Join the words with underscores and keep them lowercase.
-4. Document the pattern in the engineering handbook so every new database follows it.
+**Follow the steps.**
 
-**Practical example.**
+1. Identify the product, bounded context, or service (such as `project`, `support`, `identity`).
+2. Add a short word that describes the job: `service`, `reporting`, `warehouse`, `archive`.
+3. Join them with an underscore, all lowercase.
+4. Record the name in your internal inventory.
+
 ```sql
--- Clear, product-focused names
-CREATE DATABASE billing_service;
-CREATE DATABASE billing_reporting;
+-- ✅ Clear names
+CREATE DATABASE project_service;
+CREATE DATABASE project_reporting;
 
--- Risky, non-descriptive names
-CREATE DATABASE db_main;
-CREATE DATABASE billing2;
+-- ❌ Too vague
+CREATE DATABASE db1;
+CREATE DATABASE project2;
 ```
-The clear pair tells operators which database powers transactions and which feeds BI dashboards.
 
-> **Field Note:** Treat the database name like a customer-facing URL. If someone outside your team can guess its purpose, you chose a good name.
+## 3.2 Add environment suffixes consistently
 
-## 3.2 Handling Multiple Environments (dev, stg, prod) Safely
+**Learn the rule.** Extend the base name with `_dev`, `_stg`, `_prod`, or whatever suffixes your company standardises.
 
-**Rule.** Extend the base name with an environment suffix such as `_dev`, `_stg`, or `_prod`. Keep the suffix short, consistent, and documented.
+**Why it works.**
 
-**Why this matters.**
-- Engineers instantly know whether they are touching production data.
-- Automated pipelines can deploy to the right environment without manual switches.
-- Support teams can reproduce bugs by pointing tools at the matching environment name.
+- Connection lists show the environment immediately.
+- Deployment scripts can target the right database without manual edits.
+- On-call engineers avoid running destructive queries in production by mistake.
 
-**What goes wrong without the rule.**
-- Developers connect to the wrong database because `billing` and `billing_backup` look similar in a connection list.
-- Scripts run destructive queries on production because the environment was hidden in a config file instead of the database name.
-- Cloud providers sometimes list databases alphabetically. Without consistent suffixes, related environments drift apart and mistakes happen.
+**Follow the steps.**
 
-**How to apply it.**
-1. Start with the base product name from Section 3.1 (for example, `billing_service`).
-2. Append a short environment suffix: `_dev`, `_test`, `_stg`, `_prod`.
-3. Use the same suffix order in every project so lists stay grouped.
-4. Add monitoring alerts that look for queries to `_prod` from local developer machines.
+1. Start from the base name in Section 3.1 (`project_service`).
+2. Append the environment suffix: `_dev`, `_test`, `_stg`, `_prod`.
+3. Keep the suffix ordering identical across services so related names group together.
+4. Add automated checks that warn when someone connects to `_prod` from an unapproved network.
 
-**Practical example.**
 ```sql
--- Environment-aware names
-CREATE DATABASE billing_service_dev;
-CREATE DATABASE billing_service_stg;
-CREATE DATABASE billing_service_prod;
+-- ✅ Environment-aware
+CREATE DATABASE project_service_dev;
+CREATE DATABASE project_service_stg;
+CREATE DATABASE project_service_prod;
 
--- Risky mix of styles
-CREATE DATABASE billingDev;
-CREATE DATABASE billing_stage;
-CREATE DATABASE prod_billing;
+-- ❌ Inconsistent styles
+CREATE DATABASE ProjectServiceDEV;
+CREATE DATABASE projectStage;
+CREATE DATABASE prod_project_service;
 ```
-The consistent suffix keeps the three environments grouped and leaves no doubt about their purpose.
 
-> **Field Note:** When someone copies a connection string into a chat, the suffix acts as a final warning before anyone runs a query.
+## 3.3 Keep a predictable registry
 
-## 3.3 Why Database Names Should Be Predictable
+**Learn the rule.** Maintain a simple registry (spreadsheet or Markdown file) that lists every database, its owner, and its purpose.
 
-**Rule.** Document a naming map so every integration, script, and team knows the exact database name before connecting. Predictability is more important than creativity.
+**Why it works.**
 
-**Why this matters.**
-- Automation relies on string matching. If names follow a pattern, CI/CD jobs, backup scripts, and monitoring tools work without special cases.
-- Predictable names reduce onboarding time because new hires can guess where to find data.
-- Shared understanding prevents accidental schema duplication when teams spin up new services.
+- Automation jobs can verify the database exists before deploying.
+- Auditors and support teams know who to ask for access.
+- Renames become rare, which keeps connection strings stable.
 
-**What goes wrong without the rule.**
-- Two teams might create `billing_service` and `billing_services`, each thinking the other name was taken.
-- Auditors waste time matching database exports to business areas because nothing links the names.
-- Renaming a database to fix confusion breaks connection pools, secrets management, and firewall rules.
+**Follow the steps.**
 
-**How to apply it.**
-1. Record every database name and owner in a shared registry or `docs/database-inventory.md` file.
-2. Create a checklist for new services that requires reserving a database name before writing code.
-3. Add automated tests in deployment pipelines to verify the target database exists and matches the expected pattern.
-4. Review the registry quarterly to retire unused names and free up mental space.
+1. Create a `docs/database-inventory.md` file or similar shared list.
+2. Add a row every time you provision a database: name, owner, purpose, environment.
+3. Review the list during quarterly maintenance to retire unused databases.
+4. Link the registry from onboarding docs so newcomers find it fast.
 
-**Practical example.**
 ```text
-Inventory excerpt
-- billing_service_prod → Owned by Billing Platform Team
-- billing_service_stg → Owned by Billing Platform Team
-- billing_reporting_prod → Owned by Data Insights Team
+Example registry snippet
+- project_service_prod → Owned by Project Platform Team → Primary OLTP workload
+- project_service_stg  → Owned by Project Platform Team → Staging copy for QA
+- project_reporting_prod → Owned by Data Insights Team → BI dashboards
 ```
-This short list gives leadership and auditors instant answers about who is responsible for each data store.
 
-> **Field Note:** Predictable names save the day during an incident. When the pager goes off, responders do not have time to decode clever naming jokes.
+> **Tip:** During incidents, responders should be able to open the registry and know exactly which database to inspect. Predictable names turn chaos into a checklist.
 
 ---
 

--- a/docs/04-table-and-column-naming.md
+++ b/docs/04-table-and-column-naming.md
@@ -2,357 +2,198 @@
 
 [← Previous: Database-Level Conventions](03-database-level-conventions.md) • [Back to index](index.md) • [Next chapter →](05-constraints-and-indexes.md)
 
-Tables and columns are the backbone of every MySQL schema. This chapter explains how to name them so relationships stay clear,
-queries stay predictable, and migrations stay easy even when the database grows to millions of rows.
+Tables and columns are where the naming rules show up the most. Each section below gives you a step-by-step recipe with a working example from our sample project-tracking schema.
 
-## 4.1 Primary Keys → Why Surrogate Keys (id) Beat Natural Keys
+## 4.1 Give every table a surrogate primary key called `id`
 
-**Rule.** Give every table a single-column surrogate primary key named `id`. Let MySQL assign it automatically with `AUTO_INCREMENT` or a UUID generator.
+**Learn the rule.** Use a single-column surrogate key named `id`. Let MySQL populate it automatically (`AUTO_INCREMENT` or UUIDs).
 
-**Why this matters.**
-- Surrogate keys never change when business rules change.
-- Joining tables becomes predictable because every foreign key points to `id`.
-- ORMs and migration tools expect the pattern and behave well when it is present.
+**Why it works.**
 
-**What goes wrong without the rule.**
-- Natural keys like email addresses or phone numbers change, forcing cascading updates in child tables.
-- Composite primary keys complicate joins and lead to duplicate records when one column is missed in a query.
-- Debugging becomes slower because logs and monitoring tools cannot refer to a single identifier.
+- Surrogate keys stay stable even when business identifiers change.
+- Joins become predictable because every foreign key targets `<table>.id`.
+- ORMs and migration tools expect this pattern and behave well when they find it.
 
-**How to apply it.**
-1. Declare the primary key column as `id` with `BIGINT UNSIGNED` (or `CHAR(36)` for UUIDs).
-2. Mark it as `PRIMARY KEY` and `NOT NULL`.
-3. Use a surrogate key even if you also enforce a unique natural key (for example, email).
-4. Keep the pattern consistent across all tables so teams build muscle memory.
+**Follow the steps.**
 
-**Practical example.**
+1. Add an `id` column to every table (`BIGINT UNSIGNED` for numeric keys or `CHAR(36)` for UUIDs).
+2. Mark it `PRIMARY KEY` and `NOT NULL`.
+3. Keep business identifiers (like `project_code`) as separate unique columns.
+4. Use the same approach in every table to build muscle memory.
+
 ```sql
-CREATE TABLE customer_accounts (
+CREATE TABLE project (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    email VARCHAR(320) NOT NULL,
+    name VARCHAR(160) NOT NULL,
+    project_code CHAR(12) NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY ux_customer_accounts_email (email)
+    UNIQUE KEY ux_project_project_code (project_code)
 );
 ```
 
-> **Field Note:** Business identifiers come and go. A stable `id` column is the anchor that keeps history accurate.
+## 4.2 Name foreign keys after the referenced table + `_id`
 
-## 4.2 Foreign Keys → Why `<table>_id` Pattern Avoids Confusion
+**Learn the rule.** For a foreign key that points to `team_member.id`, name the column `team_member_id`.
 
-**Rule.** Name every foreign key column after the referenced table plus `_id`, such as `customer_id` or `order_id`.
+**Why it works.**
 
-**Why this matters.**
-- Readers understand the relationship without scanning the schema.
-- ORMs can infer associations automatically.
-- Query planners show clear join paths when column names match table names.
+- Relationships are obvious without opening schema diagrams.
+- Query builders can infer joins automatically.
+- Reviewers catch mistakes quickly because the column names match table names.
 
-**What goes wrong without the rule.**
-- Columns like `user` or `customerRef` force developers to open table definitions to confirm the link.
-- Mismatched names (`client_id` referencing `customers.id`) cause foreign keys to be skipped during migrations.
-- Accidental cross-service joins happen when teams reuse vague column names.
+**Follow the steps.**
 
-**How to apply it.**
-1. Take the referenced table name in singular form (for example, `customers` → `customer`).
-2. Append `_id` and declare the column with the same type as the primary key.
-3. Add a foreign key constraint named `fk_<table>__<referenced_table>` in Chapter 5 style.
-4. Index the column to keep joins fast.
+1. Take the referenced table in singular form (`team_member`).
+2. Append `_id` and copy the same data type as the primary key.
+3. Add an index to keep joins fast.
+4. Create the foreign key constraint using the naming style from Chapter 5.
 
-**Practical example.**
 ```sql
-CREATE TABLE customer_orders (
+CREATE TABLE project_member (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    customer_id BIGINT UNSIGNED NOT NULL,
-    total_amount_cents INT UNSIGNED NOT NULL,
+    project_id BIGINT UNSIGNED NOT NULL,
+    team_member_id BIGINT UNSIGNED NOT NULL,
+    role_code VARCHAR(32) NOT NULL,
     PRIMARY KEY (id),
-    KEY ix_customer_orders_customer_id (customer_id),
-    CONSTRAINT fk_customer_orders__customers
-        FOREIGN KEY (customer_id) REFERENCES customers (id)
+    KEY ix_project_member_project_id (project_id),
+    KEY ix_project_member_team_member_id (team_member_id)
 );
 ```
 
-> **Field Note:** When every foreign key ends with `_id`, junior developers can write correct joins on day one.
+## 4.3 Standardise audit timestamps
 
-## 4.3 Timestamps → Why Every Table Needs `created_at` and `updated_at`
+**Learn the rule.** Add `created_at` and `updated_at` to any table that changes over time. Store UTC timestamps.
 
-**Rule.** Add `created_at` and `updated_at` columns to every table that stores mutable data. Store UTC timestamps in `DATETIME` or `TIMESTAMP`.
+**Why it works.**
 
-**Why this matters.**
-- You can audit when records were inserted and last changed.
-- Change data capture tools rely on timestamps to sync downstream systems.
-- Support teams can answer "when did this happen?" without reading logs.
+- You can answer “when did this change?” in seconds.
+- Replication and change-data-capture tools rely on timestamps.
+- Support teams can investigate issues without digging through logs.
 
-**What goes wrong without the rule.**
-- Bug investigations stall because no one knows when a record appeared.
-- Batch jobs may reprocess old data because there is no easy way to filter by recent changes.
-- Deleting or archiving data becomes risky without a timeline.
+**Follow the steps.**
 
-**How to apply it.**
 1. Declare both columns as `DATETIME(6)` or `TIMESTAMP(6)` with `NOT NULL`.
-2. Default `created_at` to `CURRENT_TIMESTAMP(6)` and `updated_at` to `CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)`.
-3. Ensure application code updates `updated_at` when bulk updates bypass the automatic trigger.
-4. Keep all times in UTC to avoid daylight-saving surprises.
+2. Default `created_at` to `CURRENT_TIMESTAMP(6)`.
+3. Default `updated_at` to `CURRENT_TIMESTAMP(6)` and add `ON UPDATE CURRENT_TIMESTAMP(6)`.
+4. Keep everything in UTC to avoid daylight-saving surprises.
 
-**Practical example.**
 ```sql
-CREATE TABLE invoices (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    customer_id BIGINT UNSIGNED NOT NULL,
-    total_amount_cents INT UNSIGNED NOT NULL,
-    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
-        ON UPDATE CURRENT_TIMESTAMP(6),
-    PRIMARY KEY (id)
-);
+ALTER TABLE project
+    ADD COLUMN created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    ADD COLUMN updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+        ON UPDATE CURRENT_TIMESTAMP(6);
 ```
 
-> **Field Note:** When an incident happens, the first question is "when." These two columns provide the answer instantly.
+## 4.4 Use `deleted_at` for soft deletes
 
-## 4.4 Soft Deletes → Why `deleted_at` Beats Boolean Flags
+**Learn the rule.** Instead of a boolean `is_deleted`, store the deletion moment in a nullable `deleted_at` column.
 
-**Rule.** Represent soft deletes with a nullable `deleted_at` column instead of a boolean flag like `is_deleted`.
+**Why it works.**
 
-**Why this matters.**
-- You capture the exact moment a record became inactive.
-- Restoring data is easier because the original record stays in place.
-- Analytics can filter on a date range rather than juggling boolean logic.
+- You capture the exact time a record was archived.
+- Restoring data is a matter of clearing the timestamp.
+- Analytics can filter `deleted_at IS NULL` or compare against a date range.
 
-**What goes wrong without the rule.**
-- Boolean flags drift out of sync when bulk scripts forget to update them.
-- There is no audit trail showing when the delete occurred or who triggered it.
-- Race conditions appear when two processes toggle the flag simultaneously.
+**Follow the steps.**
 
-**How to apply it.**
-1. Add `deleted_at DATETIME(6) NULL` to tables that require soft deletes.
+1. Add `deleted_at DATETIME(6) NULL` to tables that need soft deletes.
 2. Treat any non-null value as deleted.
-3. Apply an index on `(deleted_at)` if you routinely filter active vs. deleted rows.
-4. Create views that filter `deleted_at IS NULL` for application reads.
+3. Index the column if you filter active vs. deleted rows often.
+4. Optionally create a view that hides deleted rows from application queries.
 
-**Practical example.**
 ```sql
-CREATE TABLE user_profiles (
+ALTER TABLE project_member
+    ADD COLUMN deleted_at DATETIME(6) NULL;
+```
+
+## 4.5 Preface booleans with `is_` or `has_`
+
+**Learn the rule.** Name boolean columns so they read like questions: `is_active`, `has_time_budget`.
+
+**Why it works.**
+
+- Queries and logs read like plain English.
+- Reviewers can spot misuse immediately.
+- Prevents confusion with similarly named foreign keys.
+
+**Follow the steps.**
+
+1. Start state booleans with `is_` and possession booleans with `has_`.
+2. Use `TINYINT(1) NOT NULL` with an explicit default (`0` or `1`).
+3. Avoid storing more than two states in a boolean column—switch to enums when needed.
+
+```sql
+ALTER TABLE project
+    ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1,
+    ADD COLUMN has_time_budget TINYINT(1) NOT NULL DEFAULT 0;
+```
+
+## 4.6 Make units explicit in column names
+
+**Learn the rule.** Include the measurement unit in the column name, especially for money and quantities.
+
+**Why it works.**
+
+- Prevents accidental currency or unit mix-ups.
+- Keeps exported data self-explanatory.
+- Makes refactoring easier because the scale is obvious.
+
+**Follow the steps.**
+
+1. Append the unit or scale: `_minutes`, `_cents`, `_usd`, `_grams`.
+2. Prefer integers for currency (`_cents`) to avoid rounding errors.
+3. Document conversion rules in your service README.
+
+```sql
+CREATE TABLE time_entry (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    display_name VARCHAR(120) NOT NULL,
+    project_id BIGINT UNSIGNED NOT NULL,
+    team_member_id BIGINT UNSIGNED NOT NULL,
+    logged_minutes INT UNSIGNED NOT NULL,
+    billable_amount_cents INT UNSIGNED NOT NULL,
     created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
         ON UPDATE CURRENT_TIMESTAMP(6),
-    deleted_at DATETIME(6) NULL,
     PRIMARY KEY (id)
 );
 ```
 
-> **Field Note:** A timestamp soft delete turns every "oops" moment into a reversible event.
+## 4.7 Use descriptive enums or lookup tables
 
-## 4.5 Booleans → Why `is_` and `has_` Prefixes Improve Readability
+**Learn the rule.** When a column can only hold a limited set of values, either use a lookup table or a descriptive enum name.
 
-**Rule.** Name boolean columns with `is_` or `has_` prefixes, such as `is_active` or `has_consented`.
+**Why it works.**
 
-**Why this matters.**
-- The value reads like a sentence: `is_active = 1` means "this record is active." 
-- Code reviews go faster because the intention is clear in both SQL and application code.
-- Avoids confusion with nouns that may be mistaken for foreign keys or enums.
+- The allowed values stay obvious.
+- Business users can map codes to meanings without guesswork.
+- Future changes (adding a new status) are straightforward.
 
-**What goes wrong without the rule.**
-- Columns named `active` or `status` require extra documentation.
-- Teams mix numeric flags (`0/1`) and textual flags (`Y/N`), making queries brittle.
-- Developers may store more than two states in a boolean column, causing silent bugs.
+**Follow the steps.**
 
-**How to apply it.**
-1. Start boolean names with `is_` for states and `has_` for possession.
-2. Use `TINYINT(1) NOT NULL` and default to `0` or `1` based on the safe default.
-3. Reserve enums for multi-state values instead of overloading booleans.
-4. Document any boolean defaults in migration notes.
+1. Create a lookup table when values carry extra metadata (such as `project_status`).
+2. Use a `CHECK` constraint for short, stable lists.
+3. Name enum columns with `_code` or `_status` suffixes for clarity.
 
-**Practical example.**
 ```sql
-ALTER TABLE customer_accounts
-    ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1,
-    ADD COLUMN has_marketing_opt_in TINYINT(1) NOT NULL DEFAULT 0;
-```
-
-> **Field Note:** Read the column name aloud. If it forms a true/false question, you named it well.
-
-## 4.6 Amounts & Units → Why Explicit Units Prevent Ambiguity
-
-**Rule.** Include the measurement unit or scale in the column name, especially for money and physical quantities.
-
-**Why this matters.**
-- Prevents accidental mixing of currencies or measurement systems.
-- Makes queries self-explanatory without comments.
-- Supports analytics by clarifying which conversions are required.
-
-**What goes wrong without the rule.**
-- Columns named `amount` lead to bugs when one service expects dollars and another sends cents.
-- Exported data loses context, causing downstream teams to apply the wrong math.
-- Unit changes become painful because no one knows which tables still use the old scale.
-
-**How to apply it.**
-1. Append the unit to the column name, such as `_cents`, `_usd`, `_grams`, or `_meters`.
-2. Store integers for money to avoid floating point rounding issues.
-3. Document any conversion logic in the service README.
-4. Use consistent units across the database; convert at the application boundary if needed.
-
-**Practical example.**
-```sql
-CREATE TABLE subscription_invoices (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    customer_id BIGINT UNSIGNED NOT NULL,
-    subtotal_amount_cents INT UNSIGNED NOT NULL,
-    tax_amount_cents INT UNSIGNED NOT NULL,
-    total_amount_cents INT UNSIGNED NOT NULL,
-    PRIMARY KEY (id)
-);
-```
-
-> **Field Note:** When column names say "cents" or "grams," spreadsheets stay accurate even after export.
-
-## 4.7 JSON Columns → Why `_json` Helps Contain Flexibility
-
-**Rule.** Suffix JSON columns with `_json` and restrict their use to clearly defined scenarios.
-
-**Why this matters.**
-- Signals to readers that the column stores semi-structured data.
-- Keeps search code honest—developers know to use JSON functions instead of plain SQL operators.
-- Makes it easy to audit which tables allow flexible payloads.
-
-**What goes wrong without the rule.**
-- Ambiguous names invite people to stuff arbitrary blobs into critical tables.
-- JSON usage spreads unchecked, making migrations difficult because the shape is undocumented.
-- Indexes break silently when the column type switches between JSON and text without renaming.
-
-**How to apply it.**
-1. Use names like `metadata_json` or `payload_json`.
-2. Document the allowed structure in the API or schema docs.
-3. Add JSON schema validation in the application or via MySQL `CHECK` constraints.
-4. Avoid mixing JSON with key relational data—keep the core attributes as columns.
-
-**Practical example.**
-```sql
-ALTER TABLE webhooks
-    ADD COLUMN payload_json JSON NOT NULL,
-    ADD COLUMN headers_json JSON NOT NULL;
-```
-
-> **Field Note:** A `_json` suffix is a gentle reminder that flexibility is the exception, not the rule.
-
-## 4.8 Enums vs Lookup Tables → Why Lookup Tables Scale Better
-
-**Rule.** Prefer lookup tables with foreign keys over MySQL `ENUM` types for evolving categories.
-
-**Why this matters.**
-- Lookup tables allow you to add, rename, or deactivate values without schema changes.
-- Foreign keys enforce data integrity across services.
-- Reporting queries can join for friendly labels.
-
-**What goes wrong without the rule.**
-- Updating an `ENUM` requires migrations across every environment and risks value order bugs.
-- Application code often duplicates enum values, leading to mismatched states.
-- You cannot attach metadata (like descriptions or sort order) to raw enum values.
-
-**How to apply it.**
-1. Create a lookup table with `id`, `code`, and `label` columns.
-2. Reference it from the main table with a foreign key (`status_id`).
-3. Seed the lookup table in migrations so environments stay consistent.
-4. Document how to add or retire entries through change management.
-
-**Practical example.**
-```sql
-CREATE TABLE order_statuses (
-    id TINYINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    code VARCHAR(32) NOT NULL,
-    label VARCHAR(64) NOT NULL,
-    PRIMARY KEY (id),
-    UNIQUE KEY ux_order_statuses_code (code)
+CREATE TABLE project_status (
+    status_code VARCHAR(32) PRIMARY KEY,
+    display_label VARCHAR(64) NOT NULL
 );
 
-CREATE TABLE orders (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    status_id TINYINT UNSIGNED NOT NULL,
-    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    PRIMARY KEY (id),
-    CONSTRAINT fk_orders__order_statuses
-        FOREIGN KEY (status_id) REFERENCES order_statuses (id)
-);
+ALTER TABLE project
+    ADD COLUMN status_code VARCHAR(32) NOT NULL DEFAULT 'planning',
+    ADD CONSTRAINT fk_project__project_status
+        FOREIGN KEY (status_code) REFERENCES project_status (status_code);
 ```
 
-> **Field Note:** Lookup tables turn a one-word status into a mini knowledge base that can grow with the business.
+**Checklist before ending a migration**
 
-## 4.9 History, Logs, and Backups → Why Explicit Suffixes Save Time
+- [ ] Does each table use a surrogate `id` primary key?
+- [ ] Do foreign keys follow the `<table>_id` pattern and match data types?
+- [ ] Are `created_at` and `updated_at` present on mutable tables?
+- [ ] Do soft deletes use `deleted_at`?
+- [ ] Do booleans start with `is_` or `has_`?
+- [ ] Are units spelled out in column names?
+- [ ] Are limited-value columns backed by a lookup table or clear enum name?
 
-**Rule.** Use descriptive suffixes like `_history`, `_log`, and `_backup` for tables that store derived or archival data.
-
-**Why this matters.**
-- Distinguishes primary tables from supporting tables at a glance.
-- Helps performance tuning by signaling which tables can be excluded from hot queries.
-- Keeps retention policies clear when different rules apply to each suffix.
-
-**What goes wrong without the rule.**
-- Teams confuse operational tables with audit tables and accidentally query the wrong one.
-- Storage costs climb because duplicates hide among similarly named tables.
-- Incident responders waste time locating the correct backup or log table.
-
-**How to apply it.**
-1. Keep the base noun the same as the source table, then add the suffix (for example, `payments` → `payments_history`).
-2. Store archival tables in the same schema unless compliance requires separation.
-3. Document retention and pruning policies near the table definition.
-4. Expose views that join primary and history tables when needed for analytics.
-
-**Practical example.**
-```sql
-CREATE TABLE payments (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    customer_id BIGINT UNSIGNED NOT NULL,
-    amount_cents INT UNSIGNED NOT NULL,
-    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    PRIMARY KEY (id)
-);
-
-CREATE TABLE payments_history (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    payment_id BIGINT UNSIGNED NOT NULL,
-    change_type VARCHAR(32) NOT NULL,
-    changed_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    PRIMARY KEY (id)
-);
-```
-
-> **Field Note:** Clear suffixes keep operations calm when auditors or incident teams request a data trail.
-
-## 4.10 Partitions & Shards → Why Native Partitioning Beats Table Explosion
-
-**Rule.** When scaling, prefer MySQL's native partitioning or sharding features instead of manually creating many similarly named tables.
-
-**Why this matters.**
-- Partitioning keeps the schema simple: one logical table, many storage segments.
-- Query planners can prune partitions automatically, improving performance.
-- Operations teams maintain fewer objects, reducing human error.
-
-**What goes wrong without the rule.**
-- Creating tables like `events_2023`, `events_2024`, `events_2025` fragments data and confuses tooling.
-- Application code must dynamically pick table names, leading to hard-to-test branches.
-- Dropping or archiving old data becomes a risky manual process.
-
-**How to apply it.**
-1. Design a single table with partitioning by range, list, or hash based on access patterns.
-2. Name the table after the business concept (`events`), not the partition scheme.
-3. Automate partition maintenance (adding new ones, dropping old ones) with scheduled jobs.
-4. If sharding across databases is required, encode the shard in the database name, not the table name (see Chapter 3).
-
-**Practical example.**
-```sql
-CREATE TABLE events (
-    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    occurred_at TIMESTAMP(6) NOT NULL,
-    payload_json JSON NOT NULL,
-    PRIMARY KEY (id, occurred_at)
-)
-PARTITION BY RANGE (YEAR(occurred_at)) (
-    PARTITION p2023 VALUES LESS THAN (2024),
-    PARTITION p2024 VALUES LESS THAN (2025)
-);
-```
-
-> **Field Note:** One well-partitioned table is easier to secure and monitor than a fleet of nearly identical tables.
-
----
-
-[← Previous: Database-Level Conventions](03-database-level-conventions.md) • [Back to index](index.md) • [Next chapter →](05-constraints-and-indexes.md) _(coming soon)_
+Tick every item and your table design will align with the rest of this guide.

--- a/docs/05-constraints-and-indexes.md
+++ b/docs/05-constraints-and-indexes.md
@@ -2,205 +2,166 @@
 
 [← Previous: Table & Column Naming](04-table-and-column-naming.md) • [Back to index](index.md) • [Next chapter →](06-views-routines-triggers.md)
 
-Good table and column names keep data readable, but the story is not complete until constraints and indexes are named just as clearly. When constraint names explain what they guard, error messages become self-explanatory, migrations stay predictable, and on-call engineers can fix problems without guesswork. This chapter walks through each constraint and index pattern so teams can spot issues in seconds instead of hours.
+Constraint and index names show up in error messages, migration logs, and monitoring dashboards. When the names follow a clear pattern, you can diagnose issues in seconds. This chapter follows the W3Schools flow: learn the rule, see why it matters, and copy an example.
 
-## 5.1 Why Naming Constraints Matters for Debugging
+## 5.1 Always name constraints and indexes yourself
 
-**Rule.** Give every constraint and index a deliberate name that follows a shared pattern. Never let MySQL auto-generate names.
+**Learn the rule.** Never rely on auto-generated names like `project_ibfk_1`. Define every name explicitly.
 
-**Why this matters.**
-- Error messages include the failing constraint name. If the name is meaningful, the fix is obvious.
-- Schema diff tools compare names to decide whether objects changed. Predictable names stop churn in migrations.
-- Support engineers can read logs without opening the database diagram.
+**Why it works.**
 
-**What goes wrong without the rule.**
-- Auto-generated names like `orders_ibfk_1` hide the relationship, forcing people to dig through metadata tables.
-- Renaming a column causes MySQL to rebuild unnamed indexes with new random names, generating noisy diffs.
-- Incident responders cannot tell which application rule failed, so they disable the constraint instead of fixing the data.
+- Error messages instantly tell you what failed.
+- Schema diffs stay clean across environments.
+- On-call responders can fix issues without opening the database diagram.
 
-**How to apply it.**
-1. Decide on a prefix for each constraint type (described in the next sections).
-2. Include the table name and the important columns, separated with double underscores `__` for readability.
-3. Create or alter constraints explicitly with the chosen name instead of relying on defaults.
-4. Document any exceptions inside the migration file so the next engineer understands the reason.
+**Follow the steps.**
 
-**Practical example.**
+1. Pick a prefix per object type (`pk_`, `fk_`, `ux_`, `ix_`, `ck_`, `ft_`).
+2. Include the table name and important columns.
+3. Separate sections with double underscores `__` for readability.
+4. Add the name when you create or alter the constraint.
+
 ```sql
-ALTER TABLE invoices
-    ADD CONSTRAINT fk_invoices__customer_id__customers
-        FOREIGN KEY (customer_id) REFERENCES customers (id);
+ALTER TABLE project_member
+    ADD CONSTRAINT fk_project_member__project_id__project
+        FOREIGN KEY (project_id) REFERENCES project (id);
 ```
 
-> **Field Note:** Clear names turn a 3 a.m. error message into a one-line fix. Vague names turn it into a war room.
+## 5.2 Primary keys → `pk_<table>`
 
-## 5.2 Primary Keys (`pk_<table>`)
+**Learn the rule.** Name each primary key `pk_<table>`.
 
-**Rule.** Name every primary key `pk_<table>` where `<table>` is the table name in singular form.
+**Why it works.**
 
-**Why this matters.**
-- Primary keys anchor foreign keys, so the name appears in many error messages.
-- Monitoring dashboards can alert on `pk_orders` violations and everyone knows what it means.
-- ORMs often try to create their own keys if they cannot see an existing primary key; explicit naming avoids duplication.
+- Error logs and monitoring charts reference the key clearly.
+- Tools such as Debezium and ORMs detect your intended primary key without guesswork.
+- You avoid random renames when schemas are dumped and reloaded.
 
-**What goes wrong without the rule.**
-- Default names like `PRIMARY` do not travel well in schema dumps or cross-environment comparisons.
-- Multiple teams alter the same table and accidentally drop and recreate the key because they cannot refer to it by name.
-- Cross-database tooling (for example, Debezium) may fail to detect the intended primary key when metadata is inconsistent.
+**Follow the steps.**
 
-**How to apply it.**
-1. When creating the table, declare the primary key with `CONSTRAINT pk_<table>`.
-2. Keep the name stable even if the primary key columns change (for example, switching from `INT` to `BIGINT`).
-3. Use the singular table name to match the naming pattern used for foreign keys.
+1. Declare the constraint inside the `CREATE TABLE` statement.
+2. Keep the name stable even if you swap the underlying column type.
 
-**Practical example.**
 ```sql
-CREATE TABLE payment ( 
+CREATE TABLE time_entry (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    CONSTRAINT pk_payment PRIMARY KEY (id)
+    CONSTRAINT pk_time_entry PRIMARY KEY (id)
 );
 ```
 
-> **Field Note:** A named primary key gives tools and humans a fixed handle, even if the table evolves.
+## 5.3 Foreign keys → `fk_<table>__<column>__<ref_table>`
 
-## 5.3 Foreign Keys (`fk_<table>__<column>__<ref_table>`)
+**Learn the rule.** Combine the referencing table, the foreign key column(s), and the referenced table.
 
-**Rule.** Name foreign keys `fk_<table>__<column>__<ref_table>` so the relationship is obvious.
+**Why it works.**
 
-**Why this matters.**
-- When a foreign key fails, the error points directly to the referencing table, the column, and the referenced table.
-- Code reviewers can spot mismatched relationships at a glance.
-- Automated schema checkers can verify that every `_id` column has the matching constraint.
+- The error message spells out the entire relationship.
+- Reviewers catch mismatched types or target tables quickly.
+- Automation can check that every `_id` column owns a constraint.
 
-**What goes wrong without the rule.**
-- A generic name like `fk_user1` gives no clue which column is wrong.
-- Teams end up with duplicate foreign keys because they cannot see that one already exists.
-- Deleting records fails during incidents, but on-call engineers waste time guessing which child table is blocking it.
+**Follow the steps.**
 
-**How to apply it.**
-1. Start with the table that holds the foreign key (singular form).
-2. Add the foreign key column name, even for multi-column keys (`order_id__line_number`).
-3. Finish with the referenced table (singular form).
-4. Keep underscores for words but use double underscores between sections: table, column(s), referenced table.
+1. Use the singular table names.
+2. Join multiple columns with `_` inside the middle section (`assignment_id__sequence_number`).
+3. Reference the target table’s primary key.
 
-**Practical example.**
 ```sql
-ALTER TABLE order_payment
-    ADD CONSTRAINT fk_order_payment__order_id__order
-        FOREIGN KEY (order_id) REFERENCES `order` (id);
+ALTER TABLE time_entry
+    ADD CONSTRAINT fk_time_entry__project_id__project
+        FOREIGN KEY (project_id) REFERENCES project (id);
 ```
 
-> **Field Note:** The name is a sentence: “foreign key on order_payment.order_id referencing order.” No guessing required.
+## 5.4 Unique constraints → `ux_<table>__<columns>`
 
-## 5.4 Unique Constraints (`ux_<table>__<columns>`)
+**Learn the rule.** Describe which columns must stay unique.
 
-**Rule.** Name unique constraints `ux_<table>__<columns>` to show exactly which fields must stay unique.
+**Why it works.**
 
-**Why this matters.**
-- Duplicate data is a common source of bugs; the name identifies the business rule you are protecting.
-- When analytics asks “what keeps invoice numbers unique?” you can point to `ux_invoice__number` without opening SQL.
-- Migration scripts can drop and recreate constraints safely because the name does not change when column order does.
+- Business rules stay visible to everyone.
+- Dropping or recreating the constraint in migrations is safe because the name is predictable.
+- Analytics teams can answer "what keeps this unique?" instantly.
 
-**What goes wrong without the rule.**
-- Auto-generated names differ across environments, so schema comparison tools report false differences.
-- Dropping a unique constraint becomes risky because engineers cannot be certain they are targeting the right one.
-- Business rules drift when no one remembers why the constraint exists.
+**Follow the steps.**
 
-**How to apply it.**
-1. List the table name in singular form.
-2. List the columns in column order, separated by underscores; for readability, join multi-word columns with single underscores (`start_date_end_date`).
-3. Use the same name for both the constraint and any supporting index if you explicitly create one.
-
-**Practical example.**
-```sql
-ALTER TABLE invoice
-    ADD CONSTRAINT ux_invoice__number
-        UNIQUE (number);
-```
-
-> **Field Note:** When someone proposes a change, the constraint name reminds the team of the promise the schema already makes.
-
-## 5.5 Non-Unique Indexes (`ix_<table>__<columns>`)
-
-**Rule.** Name non-unique indexes `ix_<table>__<columns>` and match the order of the indexed columns.
-
-**Why this matters.**
-- Explains why the index exists. `ix_payment__status_created_at` signals the query pattern it supports.
-- Avoids duplicate indexes with the same columns in a different order.
-- Helps performance reviews—DBAs can ask “do we still need this exact index?”
-
-**What goes wrong without the rule.**
-- Unnamed indexes are assigned numbers (`invoice_ibfk_2`) that convey nothing about their purpose.
-- Developers unknowingly create duplicates, slowing down writes and consuming storage.
-- During optimisations, teams drop helpful indexes because they cannot tell what they support.
-
-**How to apply it.**
 1. Use the singular table name.
-2. List the indexed columns in the order the query uses them; include sorting directions if relevant (`created_at_desc`).
-3. Document covering indexes by appending `_covering` when extra columns are included for `SELECT` performance.
+2. List the columns in order, separated by underscores.
+3. Reuse the same name for a supporting index if you create one manually.
 
-**Practical example.**
 ```sql
-CREATE INDEX ix_payment__status_created_at
-    ON payment (status, created_at);
+ALTER TABLE project_member
+    ADD CONSTRAINT ux_project_member__project_id_team_member_id
+        UNIQUE (project_id, team_member_id);
 ```
 
-> **Field Note:** An index name should answer “Which query are we speeding up?” in five seconds.
+## 5.5 Non-unique indexes → `ix_<table>__<columns>`
 
-## 5.6 Check Constraints (`ck_<table>__<rule>`)
+**Learn the rule.** Explain the query pattern the index supports.
 
-**Rule.** For MySQL 8.0 and later, name check constraints `ck_<table>__<rule>` to describe the business rule.
+**Why it works.**
 
-**Why this matters.**
-- Check constraints enforce simple rules in the database, keeping bad data out before it causes downstream errors.
-- A descriptive name tells reviewers what the rule is without reading the SQL expression.
-- Automated testing can verify that critical guards (for example, non-negative balances) exist in every environment.
+- Prevents duplicate indexes with the same columns.
+- Helps performance reviews decide whether the index is still needed.
+- Signals sort order or coverage when appended (`_created_at_desc`, `_covering`).
 
-**What goes wrong without the rule.**
-- If the constraint fails with a generic name, developers disable it because they think it is optional.
-- When a rule changes, teams create a second overlapping constraint instead of updating the original one.
-- Legacy tools ignore unnamed checks, leading to inconsistent behaviour across environments.
+**Follow the steps.**
 
-**How to apply it.**
-1. Summarise the rule in a short phrase, such as `amount_cents_nonneg`.
-2. Use verbs sparingly; focus on the condition enforced.
-3. Keep the expression in sync with the name so the error message stays trustworthy.
-
-**Practical example.**
-```sql
-ALTER TABLE invoice
-    ADD CONSTRAINT ck_invoice__amount_cents_nonneg
-        CHECK (amount_cents >= 0);
-```
-
-> **Field Note:** The best constraint names read like a headline: “Invoices cannot have negative amounts.”
-
-## 5.7 Full-Text Indexes (`ft_<table>__<columns>`)
-
-**Rule.** Name full-text indexes `ft_<table>__<columns>` so search-related structures are easy to spot.
-
-**Why this matters.**
-- Full-text indexes behave differently from B-tree indexes; naming them clearly prevents accidental misuse.
-- Search teams can find all text-search surfaces quickly when tuning relevance.
-- Migration scripts can recreate full-text indexes in the correct order during rebuilds.
-
-**What goes wrong without the rule.**
-- Developers mistake full-text indexes for regular ones and drop them, breaking search in production.
-- Duplicate full-text indexes are created with different stopword configurations, leading to inconsistent results.
-- Disaster recovery scripts miss unnamed full-text indexes, causing search features to degrade after restores.
-
-**How to apply it.**
 1. Use the singular table name.
-2. List the searchable columns, joined with underscores.
-3. If using multiple languages or configurations, append the locale (`__en_gb`).
+2. List columns in the order used by your query.
+3. Append suffixes such as `_desc` if the index enforces descending order.
 
-**Practical example.**
 ```sql
-CREATE FULLTEXT INDEX ft_article__title_body
-    ON article (title, body);
+CREATE INDEX ix_time_entry__project_id_logged_minutes
+    ON time_entry (project_id, logged_minutes);
 ```
 
-> **Field Note:** When search breaks, the team should find every related index by grepping for `ft_`—clear names make that possible.
+## 5.6 Check constraints → `ck_<table>__<rule>`
 
-## Wrapping Up
+**Learn the rule.** Summarise the rule inside the name.
 
-Well-named constraints and indexes act like documentation that lives inside the database. They shorten incident response, prevent duplicate structures, and make migrations safer. Adopt these patterns alongside the table and column rules from Chapter 4, and you will have a schema that explains itself to anyone who reads it.
+**Why it works.**
+
+- Error messages are self-explanatory.
+- Reviewers can confirm the expression matches the intent.
+- Prevents duplicate constraints that enforce the same rule.
+
+**Follow the steps.**
+
+1. Write a short phrase describing the rule (`minutes_nonneg`).
+2. Keep the SQL expression in sync with the name.
+3. Update the existing constraint instead of adding another one when requirements change.
+
+```sql
+ALTER TABLE time_entry
+    ADD CONSTRAINT ck_time_entry__logged_minutes_nonneg
+        CHECK (logged_minutes >= 0);
+```
+
+## 5.7 Full-text indexes → `ft_<table>__<columns>`
+
+**Learn the rule.** Label text-search structures so nobody confuses them with normal indexes.
+
+**Why it works.**
+
+- Search teams and DBAs can find all full-text surfaces quickly.
+- Avoids accidental drops during migrations.
+- Makes rebuild scripts straightforward.
+
+**Follow the steps.**
+
+1. Use the singular table name.
+2. List the searchable columns joined by underscores.
+3. Add a locale or configuration suffix when relevant (`__en_gb`).
+
+```sql
+CREATE FULLTEXT INDEX ft_project_note__title_body
+    ON project_note (title, body);
+```
+
+**Quick recap checklist**
+
+- [ ] Did you choose the prefix based on the object type?
+- [ ] Does the name include the table and columns or rule?
+- [ ] Are sections separated with double underscores for readability?
+- [ ] Will the name still make sense in an error message at 3 a.m.?
+
+If you can answer "yes" to each question, your constraints and indexes are ready for production.

--- a/docs/06-views-routines-triggers.md
+++ b/docs/06-views-routines-triggers.md
@@ -2,152 +2,140 @@
 
 [← Previous: Constraints & Indexes](05-constraints-and-indexes.md) • [Back to index](index.md) • [Next chapter →](07-migrations-and-versioning.md)
 
-Views, stored routines, and triggers sit on top of tables and columns. They shape how data is read and written, so their names must make intent obvious. When names are predictable, engineers can reuse logic safely, review changes faster, and avoid accidental behaviour hidden inside the database. This chapter shows how to name each object type and why the patterns save teams from painful debugging sessions.
+Derived objects—views, stored programs, and triggers—sit on top of your tables. A consistent naming style tells reviewers what each object does before they open the definition.
 
-## 6.1 Views (`v_<purpose>`)
+## 6.1 Views → `v_<purpose>`
 
-**Rule.** Name every view with the prefix `v_` followed by a short description of the result, such as `v_customer_balance`.
+**Learn the rule.** Prefix every view with `v_` and describe the dataset that comes back.
 
-**Why this matters.**
-- The prefix immediately tells readers that the object is a view, not a table.
-- Describing the purpose in plain words helps analysts and application code pick the right view without reading the definition.
-- Monitoring teams can distinguish real tables from reporting layers when investigating slow queries.
+**Why it works.**
 
-**What goes wrong without the rule.**
-- A view named like a table (`customer_balance`) fools ORM tools into writing to it, causing errors.
-- Teams duplicate logic because they do not realise a helpful view already exists.
-- Production incidents grow worse when a hotfix drops or rewrites a view that looked like a temporary table.
+- Anyone scanning the schema can distinguish views from tables immediately.
+- Analytics teams reuse shared logic instead of rebuilding the same SELECT statements.
+- ORMs avoid writing to views accidentally because the prefix signals "read-only." 
 
-**How to apply it.**
-1. Start with `v_` to flag the object type.
-2. Add a clear noun phrase that matches the data returned (for example, `invoice_summary`, `active_subscription`).
-3. Keep verbs out of the name. Views return datasets; actions belong to procedures.
-4. Document the business logic in the migration or source code so readers know when to use the view.
+**Follow the steps.**
 
-**Practical example.**
+1. Start with `v_`.
+2. Add a noun phrase that explains the result (`project_capacity`, `member_summary`).
+3. Keep the name action-free—views return data rather than perform work.
+
 ```sql
-CREATE OR REPLACE VIEW v_active_subscription AS
+CREATE OR REPLACE VIEW v_project_recent_activity AS
 SELECT
-    s.id AS subscription_id,
-    s.customer_id,
-    p.plan_code,
-    s.current_period_end
-FROM subscription s
-JOIN plan p ON p.id = s.plan_id
-WHERE s.status = 'active';
+    p.id AS project_id,
+    p.name,
+    te.team_member_id,
+    te.logged_minutes,
+    te.created_at
+FROM project p
+JOIN time_entry te ON te.project_id = p.id
+WHERE te.created_at >= NOW() - INTERVAL 14 DAY;
 ```
 
-> **Field Note:** Names that read like reports keep analysts from rebuilding the same SQL in dashboards.
+## 6.2 Stored procedures → `sp_<verb>_<object>`
 
-## 6.2 Stored Procedures (`sp_<verb>_<object>`)
+**Learn the rule.** Prefix procedures with `sp_`, then use a verb plus the target object.
 
-**Rule.** Name stored procedures with the prefix `sp_`, followed by a verb and the object they act on, like `sp_archive_orders`.
+**Why it works.**
 
-**Why this matters.**
-- Procedures execute actions. Verb-first names set the expectation that running the routine will change data or trigger side effects.
-- Reviews become faster because the name advertises the intent before anyone reads the body.
-- Application code can search for `sp_` to audit which routines it depends on.
+- Procedures perform actions, and the verb sets expectations.
+- Reviewers understand the side effects before reading the code.
+- Application teams can search for `sp_` to audit write paths.
 
-**What goes wrong without the rule.**
-- A procedure named `orders` looks like a table and may be called accidentally during manual work.
-- Verb-free names hide the action, leading to misuse (for example, a nightly job calling a routine that issues refunds instead of generating a report).
-- Teams create duplicate procedures with slight differences because nobody realises an existing routine handles the same task.
+**Follow the steps.**
 
-**How to apply it.**
-1. Prefix with `sp_`.
-2. Use a present-tense verb that states the action (`calculate`, `archive`, `rotate`).
-3. Add the primary object name in singular form (`invoice`, `customer_payment`).
-4. If the routine focuses on a scope such as a timeframe, suffix it (`sp_rotate_api_keys_daily`).
+1. Begin with `sp_`.
+2. Use a present-tense verb that describes the action (`close`, `rebuild`, `archive`).
+3. Add the object in singular form (`project`, `time_entry`).
+4. Append context if needed (`sp_archive_project_monthly`).
 
-**Practical example.**
 ```sql
 DELIMITER //
-CREATE PROCEDURE sp_archive_orders (IN cutoff_date DATE)
+CREATE PROCEDURE sp_archive_project (IN p_project_id BIGINT)
 BEGIN
-    UPDATE `order`
-    SET archived_at = NOW()
-    WHERE status = 'delivered'
-      AND delivered_at < cutoff_date
+    UPDATE project
+    SET is_active = 0,
+        archived_at = NOW()
+    WHERE id = p_project_id
       AND archived_at IS NULL;
 END //
 DELIMITER ;
 ```
 
-> **Field Note:** Clear procedure names stop midnight deploys from calling the wrong routine.
+## 6.3 Functions → `fn_<result>`
 
-## 6.3 Functions (`fn_<result>`)
+**Learn the rule.** Prefix stored functions with `fn_` and describe the value they return.
 
-**Rule.** Name stored functions with the prefix `fn_` followed by the value they return, such as `fn_next_invoice_number`.
+**Why it works.**
 
-**Why this matters.**
-- Functions are used inside queries; a result-focused name explains what value appears in result sets.
-- Prefixing prevents confusion with scalar columns or helper tables that use similar words.
-- Code reviewers can quickly confirm that a function returns deterministic values before allowing it in production queries.
+- Developers know immediately that the routine returns a scalar value.
+- The name clarifies where to use the function (SELECT, WHERE, or computed column).
+- Ambiguous helper names disappear.
 
-**What goes wrong without the rule.**
-- A function called `increment` hides its purpose. Does it increment invoice numbers, customer counts, or retry attempts?
-- Without the prefix, developers may call the function in application code thinking it is a stored procedure.
-- Ambiguous names hide expensive logic, leading to slow queries when functions are misused in WHERE clauses.
+**Follow the steps.**
 
-**How to apply it.**
-1. Prefix with `fn_` to signal a return value.
-2. Use nouns that describe the computed value (`due_date`, `sanitised_email`).
-3. If the function depends on context (such as tenant or timezone), include it (`fn_format_datetime_utc`).
-4. Keep names short but specific; avoid generic endings like `_value`.
+1. Start with `fn_`.
+2. Describe the computed result (`remaining_budget_minutes`).
+3. Include context when necessary (`fn_format_project_code`).
 
-**Practical example.**
 ```sql
 DELIMITER //
-CREATE FUNCTION fn_next_invoice_number(p_account_id BIGINT)
-RETURNS VARCHAR(32)
+CREATE FUNCTION fn_project_remaining_budget(p_project_id BIGINT)
+RETURNS INT
 DETERMINISTIC
 BEGIN
-    DECLARE v_next_number VARCHAR(32);
-    SELECT LPAD(COALESCE(MAX(sequence), 0) + 1, 8, '0')
-      INTO v_next_number
-    FROM invoice
-    WHERE account_id = p_account_id;
-    RETURN CONCAT('INV-', v_next_number);
+    DECLARE v_budget INT;
+    DECLARE v_logged INT;
+
+    SELECT time_budget_minutes INTO v_budget
+    FROM project
+    WHERE id = p_project_id;
+
+    SELECT COALESCE(SUM(logged_minutes), 0) INTO v_logged
+    FROM time_entry
+    WHERE project_id = p_project_id;
+
+    RETURN GREATEST(v_budget - v_logged, 0);
 END //
 DELIMITER ;
 ```
 
-> **Field Note:** When the name explains the return value, you know instantly whether it belongs in SELECT or WHERE clauses.
+## 6.4 Triggers → `trg_<table>__<timing>__<event>`
 
-## 6.4 Triggers (`trg_<table>__<event>__<timing>`)
+**Learn the rule.** Show the target table, the timing, and the event, separated by double underscores.
 
-**Rule.** Name triggers with the prefix `trg_`, followed by the table, the fired event, and the timing, separated by double underscores. Example: `trg_invoice__after__insert`.
+**Why it works.**
 
-**Why this matters.**
-- Triggers run automatically. A descriptive name helps teams trace side effects during incidents.
-- Listing table, event, and timing keeps deployments safe because reviewers see exactly when the trigger fires.
-- Tooling that exports schemas can filter `trg_` objects to confirm they align with application expectations.
+- Readers can tell exactly when the trigger fires.
+- Incident responders can search for all triggers on a table quickly.
+- Prevents confusion between similar triggers on the same table.
 
-**What goes wrong without the rule.**
-- A trigger named `update_status` hides where it lives and when it runs, causing circular updates or recursion loops.
-- Engineers forget that a trigger exists and duplicate logic in application code, causing inconsistent behaviour.
-- Debugging replication issues takes longer because the trigger’s scope is unclear.
+**Follow the steps.**
 
-**How to apply it.**
-1. Begin with `trg_`.
+1. Prefix with `trg_`.
 2. Add the table name in singular form.
-3. Insert the event (`insert`, `update`, `delete`) between double underscores.
-4. Add the timing (`before`, `after`) as the final section.
-5. Document the reason for the trigger in the migration so reviewers know why the database performs the action.
+3. Add the timing (`before`, `after`).
+4. Add the event (`insert`, `update`, `delete`).
 
-**Practical example.**
 ```sql
 DELIMITER //
-CREATE TRIGGER trg_invoice__after__insert
-AFTER INSERT ON invoice
+CREATE TRIGGER trg_time_entry__before__insert
+BEFORE INSERT ON time_entry
 FOR EACH ROW
 BEGIN
-    INSERT INTO invoice_log (invoice_id, action, occurred_at)
-    VALUES (NEW.id, 'created', NOW());
+    IF NEW.logged_minutes < 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'logged_minutes must be non-negative';
+    END IF;
 END //
 DELIMITER ;
 ```
 
-> **Field Note:** A well-named trigger announces its behaviour before you open the code.
+**Quick checklist**
 
-[← Previous: Constraints & Indexes](05-constraints-and-indexes.md) • [Back to index](index.md) • [Next chapter →](07-migrations-and-versioning.md)
+- [ ] Does the prefix tell you the object type (`v_`, `sp_`, `fn_`, `trg_`)?
+- [ ] Does the rest of the name explain the purpose, timing, or result?
+- [ ] Could someone understand the object’s intent without opening the definition?
+
+If the answer is yes, your derived objects match the convention.

--- a/docs/07-migrations-and-versioning.md
+++ b/docs/07-migrations-and-versioning.md
@@ -2,102 +2,109 @@
 
 [← Previous: Views, Routines & Triggers](06-views-routines-triggers.md) • [Back to index](index.md) • [Next chapter →](08-additional-conventions.md)
 
-Naming database objects is only half the story. Teams also need a disciplined way to name the migration files that create, change, and remove those objects. Clear migration names help everyone understand deployment order, audit changes during incidents, and roll back safely when something goes wrong. This chapter explains how to name migration files so large teams can ship changes with confidence.
+Schema changes should be as predictable as the schema itself. Use this chapter as a playbook for naming migration files and keeping version history clear.
 
-## 7.1 File Naming → Why Timestamped Names Are Essential for Ordering
+## 7.1 Timestamped filenames keep order predictable
 
-**Rule.** Prefix every migration filename with a sortable timestamp (UTC, `YYYYMMDDHHMMSS`) followed by a short, descriptive slug, such as `20240415103000_add_invoice_indexes.sql`.
+**Learn the rule.** Start every migration filename with a UTC timestamp in `YYYYMMDDHHMMSS` format, followed by a short slug: `20240718120000_add-project-status.sql`.
 
-**Why this matters.**
-- Timestamps give an absolute order so that distributed teams apply migrations in the same sequence.
-- CI/CD systems can pick up new files by comparing timestamps without reading their contents.
-- Auditors and incident responders can line up schema changes with application releases.
+**Why it works.**
 
-**What goes wrong without the rule.**
-- Natural-language names sort differently on different operating systems, causing migrations to run in a dangerous order.
-- Engineers forget to add numbers manually (`01`, `02`) and end up renumbering files, making pull requests hard to review.
-- Re-running migrations on a new environment fails because there is no reliable order to follow.
+- Timestamps sort naturally, so every environment runs migrations in the same order.
+- CI/CD jobs can detect new files by comparing timestamps.
+- Auditors can align database changes with application releases.
 
-**How to apply it.**
-1. Generate the timestamp in UTC to avoid daylight savings issues.
-2. Use a single underscore between the timestamp and the slug.
-3. Keep the slug short but specific (`create_payment_table`, `drop_legacy_trigger`).
-4. Store the script in a directory dedicated to migrations so tooling can locate it.
+**Follow the steps.**
 
-**Practical example.**
-```
-20240415103000_add_invoice_indexes.sql
-20240418120000_create_v_invoice_summary.sql
-20240422151500_sp_archive_orders.sql
+1. Generate the timestamp in UTC.
+2. Add an underscore and a hyphen-separated slug (`add-project-status` or `add_project_status`, pick one style and stick to it). This guide uses hyphenated slugs.
+3. Keep the slug short but descriptive.
+4. Store migrations in a dedicated directory (for example, `db/migrate`).
+
+```text
+20240718120000_add-project-status.sql
+20240722153000_create-v_project_recent_activity.sql
+20240725100000_sp_archive_project.sql
 ```
 
-> **Field Note:** When a deployment fails, the timestamp instantly tells you which migration to re-run and in what order.
+## 7.2 One task per migration file
 
-## 7.2 One Action/Object per File → Why Small, Atomic Changes Matter
+**Learn the rule.** Keep each file focused on a single object or closely related set of changes.
 
-**Rule.** Keep each migration focused on a single object or closely related set of changes. If you need to alter multiple tables, create multiple files.
+**Why it works.**
 
-**Why this matters.**
-- Atomic migrations are easier to review and test.
-- Rollbacks become less risky because you only undo the change that failed.
-- Merge conflicts shrink because two engineers are less likely to touch the same file.
+- Reviews stay short and clear.
+- Rollbacks only touch the failing change.
+- Merge conflicts shrink because fewer engineers edit the same file.
 
-**What goes wrong without the rule.**
-- A giant script that creates tables, triggers, and indexes at once becomes unreviewable.
-- Partial deploys leave the schema in a half-changed state that is hard to recover from.
-- When a single statement fails, the rest of the script does not run, leaving the database inconsistent.
+**Follow the steps.**
 
-**How to apply it.**
-1. Decide what the migration is responsible for (for example, create a table, add a column, drop a trigger).
-2. Write a descriptive slug that matches the action (`add_customer_timezone_column`).
-3. If you need to perform follow-up steps (such as backfilling data), place them in a separate script with its own timestamp.
-4. Document cross-file dependencies in comments so reviewers understand the sequence.
+1. Decide what the file is responsible for (create a table, add a column, drop a trigger).
+2. Name the slug to match the action (`add-time-entry-billable-flag`).
+3. If you need to backfill or clean data, add a new migration with its own timestamp.
+4. Mention dependencies in comments when one file must run before another.
 
-**Practical example.**
-```
-20240501100000_create_customer_timezone_column.sql
-20240501101000_backfill_customer_timezone.sql
-20240501102000_add_customer_timezone_index.sql
+```text
+20240730090000_add-time-entry-billable-flag.sql
+20240730090500_backfill-time-entry-billable-flag.sql
+20240730091000_add-time-entry-billable-index.sql
 ```
 
-> **Field Note:** When you keep migrations small, you can roll back one slice without touching other parts of the release.
+## 7.3 Document rollbacks right in the file
 
-## 7.3 Rollback & CI/CD Safety
+**Learn the rule.** Write a short header comment describing the change, its purpose, and how to undo it. When you store rollback scripts separately, reuse the same timestamp.
 
-**Rule.** For every migration, plan the rollback path and record it in the file header. Use consistent naming so automated tools can pair forward and backward steps.
+**Why it works.**
 
-**Why this matters.**
-- Deployments occasionally fail. A documented rollback lets teams recover without delay.
-- CI/CD pipelines can enforce that every forward script has a matching rollback script when names follow a pattern.
-- Future engineers know the intent behind the change when they read the file years later.
+- On-call engineers know exactly how to reverse the change.
+- CI/CD pipelines can pair forward and backward files reliably.
+- Future teammates understand why the migration exists.
 
-**What goes wrong without the rule.**
-- A hotfix removes a column, but nobody remembers how to rebuild it when the fix fails.
-- Rollback scripts are named inconsistently, so the pipeline cannot find them and aborts the deploy.
-- New environments drift because initial setup migrations include destructive statements without safety notes.
+**Follow the steps.**
 
-**How to apply it.**
-1. Add a header comment describing the change, the reason, and the rollback steps.
-2. If the team uses paired files, follow a shared pattern (for example, `20240502090000_add_index.sql` and `20240502090000_add_index_down.sql`).
-3. Test the rollback locally or in staging before merging the migration.
-4. Include guards such as `IF EXISTS` and `IF NOT EXISTS` to keep reruns safe.
+1. Start each file with comments explaining the forward change and the rollback path.
+2. If you keep paired scripts, name the rollback `<timestamp>_<slug>_down.sql`.
+3. Test both forward and backward scripts in staging before release.
+4. Use safety guards like `IF EXISTS` for destructive actions.
 
-**Practical example.**
 ```sql
--- 20240502090000_add_index.sql
--- Adds ix_invoice__customer_id_created_at for dashboard performance.
--- Rollback: drop the index with 20240502090000_add_index_down.sql
-ALTER TABLE invoice
-    ADD INDEX ix_invoice__customer_id_created_at (customer_id, created_at);
+-- 20240718120000_add-project-status.sql
+-- Adds project_status table and links it to project.status_code.
+-- Rollback: run 20240718120000_add-project-status_down.sql to drop the table and column.
+START TRANSACTION;
+
+CREATE TABLE project_status (
+    status_code VARCHAR(32) PRIMARY KEY,
+    display_label VARCHAR(64) NOT NULL
+);
+
+ALTER TABLE project
+    ADD COLUMN status_code VARCHAR(32) NOT NULL DEFAULT 'planning',
+    ADD CONSTRAINT fk_project__project_status
+        FOREIGN KEY (status_code) REFERENCES project_status (status_code);
+
+COMMIT;
 ```
 
 ```sql
--- 20240502090000_add_index_down.sql
--- Rollback for 20240502090000_add_index.sql
-ALTER TABLE invoice
-    DROP INDEX ix_invoice__customer_id_created_at;
+-- 20240718120000_add-project-status_down.sql
+-- Rollback for 20240718120000_add-project-status.sql
+START TRANSACTION;
+
+ALTER TABLE project
+    DROP FOREIGN KEY fk_project__project_status,
+    DROP COLUMN status_code;
+
+DROP TABLE project_status;
+
+COMMIT;
 ```
 
-> **Field Note:** Naming rollback files with the same timestamp keeps automation from guessing.
+**Checklist**
 
-[← Previous: Views, Routines & Triggers](06-views-routines-triggers.md) • [Back to index](index.md) • [Next chapter →](08-additional-conventions.md)
+- [ ] Does the filename begin with a UTC timestamp?
+- [ ] Does the slug describe one clear action?
+- [ ] Is the change limited to a single object or tightly related set?
+- [ ] Are rollback instructions documented and, if needed, scripted?
+
+If all boxes are checked, your migration naming is ready for production.

--- a/docs/08-additional-conventions.md
+++ b/docs/08-additional-conventions.md
@@ -2,364 +2,178 @@
 
 [← Previous: Migrations & Versioning](07-migrations-and-versioning.md) • [Back to index](index.md) • [Next chapter →](09-examples-and-patterns.md)
 
-These conventions do not fit into a single object type, yet they protect every MySQL project once it starts to grow. Think of them as the safety net around the core naming rules. Each section explains the recommendation, the pain you avoid by following it, and a simple way to put the idea into practice.
+These tips wrap around the core rules and become invaluable as your MySQL installation grows. Each mini-lesson follows the same pattern: learn the idea, understand why it matters, and apply it with a quick example.
 
-## 8.1 Character Sets & Collations → Why utf8mb4 Is the Only Safe Default
+## 8.1 Standardise character sets and collations
 
-**Rule.** Set every database, table, and column that stores text to use the `utf8mb4` character set with a modern collation such as `utf8mb4_unicode_ci` (case-insensitive) or `utf8mb4_0900_ai_ci` (MySQL 8+).
+**Learn the rule.** Use `utf8mb4` everywhere with a modern collation such as `utf8mb4_unicode_ci` (case-insensitive) or `utf8mb4_0900_ai_ci` (MySQL 8+).
 
-**Why this matters.**
-- `utf8mb4` stores the full Unicode range, including emoji and multilingual names.
-- A consistent collation keeps string comparisons predictable across the schema.
-- Tooling (ORMs, ETL jobs, BI tools) assumes Unicode support and fails when it is missing.
+**Why it works.**
 
-**What goes wrong without the rule.**
-- The legacy `utf8` charset silently truncates four-byte characters such as emoji or some Asian scripts.
-- Mixed collations (`utf8_general_ci`, `latin1_swedish_ci`) make joins and sorting inconsistent, leading to hidden data bugs.
-- Different collations block index usage because MySQL must perform conversions during comparisons.
+- Supports every Unicode character, including emoji and multi-language names.
+- Keeps sorting and comparisons consistent across tables.
+- Plays nicely with ORMs and analytics tools that expect Unicode.
 
-**How to apply it.**
-1. Set the database default: `CREATE DATABASE app_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;`
-2. Repeat the setting on each table in case the database default changes later.
-3. Declare character sets on text columns explicitly to protect against accidental drift in migrations.
+**Follow the steps.**
 
-**Practical example.**
+1. Set the database default when you create it.
+2. Repeat the setting on each table to guard against future default changes.
+3. Declare the charset and collation on text columns explicitly in migrations.
+
 ```sql
-CREATE TABLE customer (
+CREATE TABLE team_member (
     id BIGINT UNSIGNED PRIMARY KEY,
     full_name VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
     email VARCHAR(320) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
 ) CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 ```
 
-> **Field Note:** Aligning character sets from the start prevents a painful rewrite when you expand to international markets.
+## 8.2 Store time in UTC and suffix with `_at`
 
-## 8.2 Time Handling → Why Always Store UTC with `_at`
+**Learn the rule.** Keep all timestamps in UTC and end the column name with `_at`.
 
-**Rule.** Store all timestamps in UTC, name the columns with an `_at` suffix, and convert to local time only in the application or reporting layer.
+**Why it works.**
 
-**Why this matters.**
-- UTC avoids daylight saving issues and regional time zone confusion.
-- The `_at` suffix signals that the column records a point in time, not just a date.
-- Logging, analytics, and cross-service integrations can compare timestamps without extra conversion rules.
+- Avoids daylight-saving glitches.
+- Makes event ordering easy across services.
+- `_at` instantly signals “point in time.”
 
-**What goes wrong without the rule.**
-- Local time storage causes gaps or duplicate times when clocks move forward or backward.
-- Engineers misread columns like `created` or `event_time` and apply incorrect logic.
-- External systems reject data when they receive ambiguous or timezone-free timestamps.
+**Follow the steps.**
 
-**How to apply it.**
-1. Declare timestamp columns as `DATETIME` or `TIMESTAMP` and add `_at` (`created_at`, `processed_at`).
-2. Normalize incoming times to UTC in the application before writing to MySQL.
-3. Document how clients should convert back to local time for display.
+1. Normalize incoming times to UTC before persisting.
+2. Name the column `created_at`, `processed_at`, etc.
+3. Document how to convert for display in the application layer.
 
-**Practical example.**
 ```sql
-ALTER TABLE payment
-    ADD COLUMN processed_at DATETIME NOT NULL COMMENT 'UTC timestamp when the payment gateway confirmed processing';
+ALTER TABLE time_entry
+    ADD COLUMN submitted_at DATETIME NOT NULL COMMENT 'UTC timestamp when the entry was submitted by the member';
 ```
 
-> **Field Note:** When an incident spans services in different time zones, consistent `_at` columns allow fast event correlation.
+## 8.3 Choose between `TIMESTAMP` and `DATETIME` on purpose
 
-## 8.3 DATETIME vs TIMESTAMP → Differences, Trade-offs, and Best Practices
+**Learn the rule.** Use `TIMESTAMP` for audit columns that stay within 1970–2038 UTC, and `DATETIME` for business events outside that range.
 
-**Rule.** Use `TIMESTAMP` when you need automatic `CURRENT_TIMESTAMP` behaviour and the stored range fits (1970–2038 UTC). Use `DATETIME` for anything else.
+**Why it works.**
 
-**Why this matters.**
-- `TIMESTAMP` values are stored in UTC and auto-convert with time zones when MySQL knows the session offset.
-- `DATETIME` stores the exact value you write, preserving historical dates and future schedules.
-- Choosing deliberately prevents silent wraparound or conversion bugs.
+- Prevents overflow bugs in far-future schedules.
+- Keeps automatic `CURRENT_TIMESTAMP` behaviour where you need it.
+- Documented choices stop accidental type swaps later.
 
-**What goes wrong without the rule.**
-- Using `TIMESTAMP` for far-future dates (like subscription renewals) causes overflow after 2038.
-- Using `DATETIME` for audit columns and relying on `DEFAULT CURRENT_TIMESTAMP` fails because the default does not update automatically.
-- Mixing both types within the same concept confuses ORMs and data warehouse jobs.
+**Follow the steps.**
 
-**How to apply it.**
-1. Pick `TIMESTAMP` for operational audit columns (`created_at`, `updated_at`) when they stay within the supported range.
-2. Pick `DATETIME` for business events (contract start dates, scheduled reminders) that may go beyond 2038.
-3. State the choice in table comments so future migrations keep the same type.
+1. Use `TIMESTAMP` for `created_at` and `updated_at` fields.
+2. Use `DATETIME` for scheduling (`kickoff_at`, `renewal_at`).
+3. Mention the reason in a column comment.
 
-**Practical example.**
 ```sql
-CREATE TABLE subscription (
+CREATE TABLE project_schedule (
     id BIGINT UNSIGNED PRIMARY KEY,
-    customer_id BIGINT UNSIGNED NOT NULL,
+    project_id BIGINT UNSIGNED NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    renews_at DATETIME NOT NULL COMMENT 'UTC time when the subscription renews after 2038-safe range'
+    kickoff_at DATETIME NOT NULL COMMENT 'UTC meeting start time, can extend beyond 2038'
 );
 ```
 
-> **Field Note:** Teams that mix `DATETIME` and `TIMESTAMP` at random often hit bugs only after the system has been live for years.
+## 8.4 Use precise types and lengths
 
-## 8.4 Explicit Types & Lengths → Why `VARCHAR(320)` Beats `TEXT`
+**Learn the rule.** Match column types to the real-world values instead of falling back to generic `TEXT` or oversized lengths.
 
-**Rule.** Define precise data types and lengths that match the business meaning instead of falling back to `TEXT` or overly wide defaults.
+**Why it works.**
 
-**Why this matters.**
-- Clear limits stop bad data at the database edge instead of leaking into the application.
-- Precise types keep indexes smaller and faster.
-- Reviewers can understand intent quickly when the length communicates business rules (for example, 320 characters for email addresses).
+- Keeps indexes compact and fast.
+- Stops bad data at the database boundary.
+- Communicates business rules right inside the schema.
 
-**What goes wrong without the rule.**
-- `TEXT` columns cannot use some indexes without extra steps, slowing down lookups.
-- Unlimited lengths hide data quality problems until the application crashes or external partners reject payloads.
-- ORMs map generic types differently, creating inconsistent schemas across services.
+**Follow the steps.**
 
-**How to apply it.**
-1. Research the real-world maximum (email addresses: 320 characters; ISO country codes: 2 letters).
-2. Document the reason for any unusual length in a column comment.
-3. Add check constraints when the value has a predictable format (for example, length or pattern checks).
+1. Research real limits (email: 320 chars, ISO country: 2 chars).
+2. Note unusual lengths in column comments.
+3. Add `CHECK` constraints for patterns when useful.
 
-**Practical example.**
 ```sql
-ALTER TABLE customer
-    MODIFY email VARCHAR(320) NOT NULL COMMENT 'Maximum length defined by RFC 5321';
+ALTER TABLE project
+    ADD COLUMN sponsor_email VARCHAR(320) NOT NULL COMMENT 'Length per RFC 5321';
 ```
 
-> **Field Note:** When lengths match business rules, developers spend less time validating data in every service.
+## 8.5 Default to `NOT NULL`
 
-## 8.5 Nullability → Why `NOT NULL` Should Be Default
+**Learn the rule.** Declare columns `NOT NULL` unless a nullable state carries business meaning.
 
-**Rule.** Declare columns as `NOT NULL` unless you have a clear, documented reason to allow missing values.
+**Why it works.**
 
-**Why this matters.**
-- `NOT NULL` removes a full class of bugs where code forgets to handle `NULL`.
-- Queries run faster because MySQL can store fixed-length rows and skip nullable checks.
-- Reviewers can tell that every row is expected to have a value, improving data trust.
+- Reduces branching in application code.
+- Improves storage layout and query planning.
+- Makes dashboards and reports cleaner.
 
-**What goes wrong without the rule.**
-- Analytics dashboards show gaps because `NULL` values propagate through calculations.
-- Application code becomes littered with `IFNULL()` or conditional logic to handle missing values.
-- Indexes on nullable columns can produce unexpected ordering and filtering behaviour.
+**Follow the steps.**
 
-**How to apply it.**
-1. Start with `NOT NULL` on new columns and provide a default if necessary.
-2. When `NULL` is meaningful, explain it in a comment (for example, `deleted_at DATETIME NULL -- NULL means record is active`).
-3. Backfill existing rows before flipping a column from nullable to `NOT NULL` to avoid migration failures.
+1. Start with `NOT NULL` on new columns.
+2. Provide a safe default or backfill before enforcing it.
+3. If `NULL` is meaningful, explain it in a comment.
 
-**Practical example.**
 ```sql
-ALTER TABLE invoice
-    ADD COLUMN due_at DATETIME NOT NULL COMMENT 'Every invoice must have a payment deadline';
+ALTER TABLE project
+    ADD COLUMN review_deadline_at DATETIME NOT NULL COMMENT 'Every project has a review milestone';
 ```
 
-> **Field Note:** Treating `NOT NULL` as the norm forces teams to think through nullable business cases deliberately.
+## 8.6 Provide public IDs alongside internal IDs
 
-## 8.6 IDs → Why Dual IDs (`id` + `public_id`) Improve Internal/External Safety
+**Learn the rule.** Use a fast numeric `id` internally and expose a separate `public_id` (UUID or token) to external clients.
 
-**Rule.** Use an internal numeric `id` as the primary key and expose a separate `public_id` (often a UUID or prefixed token) for external clients.
+**Why it works.**
 
-**Why this matters.**
-- Internal IDs remain short, fast, and efficient for joins and indexing.
-- Public IDs can follow business-friendly patterns without revealing internal counts.
-- Security reviews approve systems faster when sequential IDs are not exposed to customers.
+- Internal joins stay efficient.
+- Public APIs avoid predictable, sequential identifiers.
+- Rotating external identifiers does not disturb relational integrity.
 
-**What goes wrong without the rule.**
-- Guessable IDs allow customers to fetch other users’ records by incrementing numbers.
-- Migrations that change primary key type break API contracts when the same field is shared everywhere.
-- Data warehouse exports leak sensitive information because internal and public IDs are the same.
+**Follow the steps.**
 
-**How to apply it.**
-1. Keep `id BIGINT UNSIGNED AUTO_INCREMENT` as the clustered primary key.
-2. Add `public_id CHAR(27)` or `CHAR(36)` for UUIDs and enforce uniqueness with `UNIQUE KEY ux_<table>__public_id`.
-3. Generate the public ID in the application or with a trigger, and document the format.
+1. Keep `id BIGINT UNSIGNED AUTO_INCREMENT` as the primary key.
+2. Add `public_id CHAR(27)` or `CHAR(36)` with a unique constraint.
+3. Generate the public ID in application code or via a trigger.
 
-**Practical example.**
 ```sql
-CREATE TABLE api_token (
+CREATE TABLE project_invitation (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    public_id CHAR(27) NOT NULL COMMENT 'External token id like tok_abc123',
-    user_id BIGINT UNSIGNED NOT NULL,
-    created_at DATETIME NOT NULL,
-    UNIQUE KEY ux_api_token__public_id (public_id)
+    public_id CHAR(27) NOT NULL,
+    project_id BIGINT UNSIGNED NOT NULL,
+    issued_at DATETIME NOT NULL,
+    UNIQUE KEY ux_project_invitation__public_id (public_id)
 );
 ```
 
-> **Field Note:** Dual identifiers let you rotate public tokens without touching the relational core of the schema.
+## 8.7 Avoid name collisions with reserved words or vague terms
 
-## 8.7 Naming Collisions → Why Extending Reserved Names Prevents Bugs
+**Learn the rule.** Do not use bare reserved words or ambiguous nouns. Extend them with clarifiers.
 
-**Rule.** Avoid using bare reserved words or overloaded business terms. Extend the name with a qualifier that clarifies the meaning.
+**Why it works.**
 
-**Why this matters.**
-- Reserved words (`order`, `group`, `user`) require quoting, which clutters queries and breaks ORM generators.
-- Clear qualifiers (`order_number`, `group_account`) reduce confusion between similar concepts.
-- Shared schemas across services stay compatible when the names are explicit.
+- Prevents constant quoting (`SELECT * FROM `order``) and ORM issues.
+- Makes cross-team integrations clearer (`status_code`, `member_role`).
+- Reduces misunderstandings during handoffs.
 
-**Common collision scenarios.**
-- **Reserved words:** `order`, `select`, `index`, `key`.
-- **Overloaded terms:** `status`, `type`, `name` when multiple meanings exist.
-- **Cross-service reuse:** Two services calling different objects `account` even though one tracks customers and the other tracks billing entities.
+**Follow the steps.**
 
-**What goes wrong without the rule.**
-- Developers wrap names in backticks and eventually forget, causing production SQL errors.
-- Automated tools (report builders, ORM migrations) fail because they do not escape identifiers consistently.
-- Teams misinterpret columns, leading to bugs during data integrations.
+1. Check the MySQL reserved word list before naming.
+2. Add context words: `purchase_order`, `member_group`, `project_status_code`.
+3. Document approved terminology in your team glossary.
 
-**How to apply it.**
-1. Review new tables and columns against the MySQL reserved word list.
-2. Add a meaningful suffix or prefix (`order_record`, `group_membership`, `status_code`).
-3. Document naming decisions in pull requests so other teams reuse the same pattern.
-
-**Practical example.**
 ```sql
--- Unsafe
-CREATE TABLE `order` (
-    `id` BIGINT UNSIGNED PRIMARY KEY
-);
-
--- Safe
-CREATE TABLE sales_order (
-    id BIGINT UNSIGNED PRIMARY KEY
+CREATE TABLE member_role (
+    role_code VARCHAR(32) PRIMARY KEY,
+    display_label VARCHAR(64) NOT NULL
 );
 ```
 
-> **Field Note:** A few extra letters now save hours of debugging when SQL clients treat reserved words differently.
+**Scaling checklist**
 
-## 8.8 API Alignment → Why DB Schema Should Mirror API Fields
+- [ ] Is `utf8mb4` the default everywhere?
+- [ ] Are timestamps stored in UTC with `_at` names?
+- [ ] Did you choose `TIMESTAMP` vs `DATETIME` deliberately?
+- [ ] Do column types and lengths reflect real-world limits?
+- [ ] Are new columns `NOT NULL` by default?
+- [ ] Do public APIs expose dedicated identifiers?
+- [ ] Did you avoid reserved or overloaded words?
 
-**Rule.** When an API exposes data from the database, align the column names with the API fields wherever practical.
-
-**Why this matters.**
-- Engineers can trace a request from the API to the database without translation tables.
-- Documentation stays consistent because the same name appears in backend and frontend guides.
-- Analytics teams reduce mapping errors when exporting data for dashboards.
-
-**What goes wrong without the rule.**
-- Application layers create fragile translation maps (`db_user_name` → `displayName`) that drift over time.
-- Debugging becomes slower because logs and queries use different vocabulary.
-- Integrations break when API changes do not cascade to the database schema.
-
-**How to apply it.**
-1. Confirm that the API name is clear and follows the core naming rules.
-2. Use that same name for the database column, adjusting only for MySQL style (snake case, `_id`, `_at`).
-3. Record exceptions (for example, legacy fields) in the API documentation so everyone knows the mapping.
-
-**Practical example.**
-```sql
--- API field: billing_address_line1
-ALTER TABLE invoice
-    ADD COLUMN billing_address_line1 VARCHAR(120) NOT NULL;
-```
-
-> **Field Note:** Aligning names across layers removes translation bugs when incident response teams search logs and tables simultaneously.
-
-## 8.9 Archival Tables (`_archive`) → Why Separation Improves Performance
-
-**Rule.** Move cold or historical data into tables with an `_archive` suffix once it is no longer needed for day-to-day queries.
-
-**Why this matters.**
-- Hot tables stay small, so primary queries remain fast and indexes stay efficient.
-- Archival tables keep history for audits without slowing down regular operations.
-- The suffix signals to everyone that the table has different retention and backup rules.
-
-**What goes wrong without the rule.**
-- Production tables grow endlessly, causing queries and backups to slow down.
-- Engineers accidentally modify historical rows because they cannot distinguish them from live data.
-- Storage costs spike when no one knows what can be purged safely.
-
-**How to apply it.**
-1. Create an archival table with the same structure as the live table plus metadata columns (`archived_at`).
-2. Use scheduled jobs to move old rows and delete them from the live table.
-3. Update documentation to explain the retention policy and how to query the archive.
-
-**Practical example.**
-```sql
-CREATE TABLE invoice_archive LIKE invoice;
-ALTER TABLE invoice_archive
-    ADD COLUMN archived_at DATETIME NOT NULL;
-```
-
-> **Field Note:** When performance issues appear, having `_archive` tables lets you trim hot data without losing compliance history.
-
-## 8.10 Temporary Tables (`tmp_...`) → Why Explicit Naming Avoids Accidents
-
-**Rule.** Prefix ad-hoc or session-level temporary tables with `tmp_` and drop them as soon as you finish using them.
-
-**Why this matters.**
-- The prefix warns everyone that the table is disposable and not part of the core schema.
-- Automated cleanup scripts can find and remove leftover temp tables safely.
-- Monitoring dashboards can filter out these tables when checking schema drift.
-
-**What goes wrong without the rule.**
-- Forgotten temporary tables stick around, confusing schema diff tools.
-- Another engineer mistakes a temporary table for production data and writes queries against it.
-- Naming collisions occur when two processes create helper tables with the same name.
-
-**How to apply it.**
-1. Choose names like `tmp_customer_backfill_202405` when running maintenance scripts.
-2. Add comments inside the script reminding the operator to drop the table.
-3. Use MySQL temporary tables (`CREATE TEMPORARY TABLE tmp_name ...`) when possible so they auto-drop on session close.
-
-**Practical example.**
-```sql
-CREATE TEMPORARY TABLE tmp_customer_backfill_202405 AS
-SELECT id, email FROM customer WHERE marketing_opt_in = 1;
--- Process rows...
-DROP TEMPORARY TABLE IF EXISTS tmp_customer_backfill_202405;
-```
-
-> **Field Note:** Consistent prefixes allow DBAs to search for `tmp_%` and remove stale tables after incident drills.
-
-## 8.11 Consistency Over Cleverness → Why Exceptions Must Be Documented
-
-**Rule.** Stick to the established naming patterns unless a documented business requirement forces an exception.
-
-**Why this matters.**
-- Consistency reduces cognitive load for every engineer reviewing queries or migrations.
-- Exceptions become a shared decision, not a personal preference.
-- Documentation helps newcomers understand why a pattern differs in one area.
-
-**What goes wrong without the rule.**
-- Developers introduce creative names that break automation scripts and style guides.
-- Reviewers waste time arguing about style instead of focusing on data correctness.
-- Future migrations copy the exception accidentally, spreading inconsistent names.
-
-**How to apply it.**
-1. When a deviation is unavoidable, explain the reason in the migration or table comment.
-2. Add the exception to internal docs or the repository wiki with the agreed-upon context.
-3. Revisit exceptions regularly to see if they can be removed after the temporary need passes.
-
-**Practical example.**
-```sql
--- Exception: Legacy partner requires camelCase column name
-ALTER TABLE partner_ledger
-    ADD COLUMN partnerLedgerId VARCHAR(40) NOT NULL COMMENT 'Exception agreed with Partner API v1';
-```
-
-> **Field Note:** Writing down exceptions signals that the rest of the schema should keep following the rules.
-
-## 8.12 Defaults: Database vs Application — When to Use Which
-
-**Rule.** Let the database manage mechanical defaults (timestamps, auto-increment IDs) and keep business defaults (status codes, feature flags) in the application layer.
-
-**Why this matters.**
-- Database defaults ensure consistent system-generated values such as `created_at` without depending on the application.
-- Business logic in the application stays transparent and version-controlled.
-- Splitting responsibilities avoids magic values that nobody remembers.
-
-**What goes wrong without the rule.**
-- Setting business defaults in the database hides behaviour from code reviewers and leads to surprises in new services.
-- Relying on the application for `created_at` timestamps causes missing values when background jobs forget to set them.
-- Overusing defaults like `'0000-00-00'` or empty strings makes it hard to tell real data from placeholders.
-
-**How to apply it.**
-1. Use database defaults for audit columns (`DEFAULT CURRENT_TIMESTAMP`) and surrogate keys (`AUTO_INCREMENT`).
-2. Set business statuses in the application after validating the rules.
-3. Avoid placeholder defaults that do not represent real data; prefer `NOT NULL` with meaningful values.
-
-**Practical example.**
-```sql
-CREATE TABLE feature_flag (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    key_name VARCHAR(120) NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    status VARCHAR(20) NOT NULL COMMENT 'Set by application after validation'
-);
-```
-
-> **Field Note:** Clear responsibility for defaults keeps your schema portable across services and environments.
-
-[← Previous: Migrations & Versioning](07-migrations-and-versioning.md) • [Back to index](index.md) • [Next chapter →](09-examples-and-patterns.md)
+If you hit “yes” on each point, your schema is ready for rapid growth.

--- a/docs/09-examples-and-patterns.md
+++ b/docs/09-examples-and-patterns.md
@@ -2,184 +2,158 @@
 
 [← Previous: Additional Conventions That Pay Off at Scale](08-additional-conventions.md) • [Back to index](index.md) • [Next chapter →](10-cheat-sheet.md)
 
-This chapter turns the naming rules into a working example. We build a small commerce data model with three tables, wire up the constraints, add a reporting view, write a helper function and trigger, and finish with a migration script. Each section explains why the names follow the standard and what would go wrong if we cut corners.
+This chapter turns the rules into a small, consistent scenario: a project-tracking application. You will see tables, constraints, routines, a view, and a migration file that all follow the conventions from earlier chapters.
 
-## 9.1 Example Schema: `user`, `currency`, `order`
+## 9.1 Example schema: `project`, `team_member`, `time_entry`
 
 ### Design goals
-- Show how lowercase snake case keeps object names readable.
-- Demonstrate consistent suffixes such as `_id`, `_at`, and `_amount`.
-- Highlight how descriptive names make joins and reports self-explanatory.
+
+- Demonstrate lower_snake_case across the entire schema.
+- Show how surrogate keys and foreign keys use the `_id` pattern.
+- Highlight explicit units (`_minutes`, `_cents`) and timestamps (`_at`).
 
 ### Table definitions
-The three core tables mirror a real checkout flow. `user` stores account details, `currency` stores allowed ISO codes, and `order` records purchases.
 
 ```sql
-CREATE TABLE `user` (
+CREATE TABLE project (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    public_id CHAR(26) NOT NULL UNIQUE COMMENT 'Short ID shared with customers',
-    email VARCHAR(320) NOT NULL UNIQUE,
+    public_id CHAR(27) NOT NULL,
+    name VARCHAR(160) NOT NULL,
+    time_budget_minutes INT UNSIGNED NOT NULL DEFAULT 0,
+    status_code VARCHAR(32) NOT NULL DEFAULT 'planning',
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    archived_at DATETIME NULL,
+    UNIQUE KEY ux_project__public_id (public_id)
+);
+
+CREATE TABLE team_member (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     full_name VARCHAR(200) NOT NULL,
-    preferred_currency_code CHAR(3) NOT NULL,
+    email VARCHAR(320) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at DATETIME NULL,
-    CONSTRAINT fk_user_currency
-        FOREIGN KEY (preferred_currency_code)
-        REFERENCES currency (code)
-        ON UPDATE CASCADE
+    UNIQUE KEY ux_team_member__email (email)
 );
 
-CREATE TABLE currency (
-    code CHAR(3) PRIMARY KEY COMMENT 'ISO 4217 currency code',
-    name VARCHAR(64) NOT NULL,
-    fraction SMALLINT UNSIGNED NOT NULL COMMENT 'Number of fractional digits'
-);
-
-CREATE TABLE `order` (
+CREATE TABLE time_entry (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    public_id CHAR(26) NOT NULL UNIQUE,
-    user_id BIGINT UNSIGNED NOT NULL,
-    currency_code CHAR(3) NOT NULL,
-    total_amount_cents BIGINT UNSIGNED NOT NULL,
-    status VARCHAR(32) NOT NULL,
-    placed_at DATETIME NOT NULL,
-    fulfilled_at DATETIME NULL,
+    project_id BIGINT UNSIGNED NOT NULL,
+    team_member_id BIGINT UNSIGNED NOT NULL,
+    logged_minutes INT UNSIGNED NOT NULL,
+    billable_amount_cents INT UNSIGNED NOT NULL,
+    submitted_at DATETIME NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    CONSTRAINT fk_order_user
-        FOREIGN KEY (user_id) REFERENCES `user` (id),
-    CONSTRAINT fk_order_currency
-        FOREIGN KEY (currency_code) REFERENCES currency (code)
+    CONSTRAINT fk_time_entry__project_id__project
+        FOREIGN KEY (project_id) REFERENCES project (id),
+    CONSTRAINT fk_time_entry__team_member_id__team_member
+        FOREIGN KEY (team_member_id) REFERENCES team_member (id)
 );
 ```
 
 ### Why the names matter
-- Readers can guess relationships: `user_id` points to `user.id`, `currency_code` points to `currency.code`.
-- Timestamp columns share the `_at` suffix so a report can scan for date fields quickly.
-- `total_amount_cents` makes the unit explicit; `total_amount` alone would force readers to check documentation.
 
-> **Field Note:** Using consistent names across tables lets BI tools auto-discover joins instead of requiring manual mapping.
+- Each table uses a surrogate `id` and optional public identifier when needed.
+- Foreign keys mirror the referenced table names, so joins read naturally.
+- Units and suffixes make queries self-explanatory (`logged_minutes`, `submitted_at`).
 
-## 9.2 Example Constraints & Indexes
-
-Constraints and indexes deserve descriptive names too. They explain intent when MySQL throws errors or when you inspect the schema with tooling.
+## 9.2 Example constraints and indexes
 
 ```sql
-ALTER TABLE `user`
-    ADD CONSTRAINT ux_user_email UNIQUE (email),
-    ADD INDEX ix_user_deleted_at (deleted_at);
+ALTER TABLE project
+    ADD CONSTRAINT ck_project__time_budget_minutes_nonneg
+        CHECK (time_budget_minutes >= 0);
 
-ALTER TABLE `order`
-    ADD CONSTRAINT ck_order_status
-        CHECK (status IN ('pending', 'paid', 'refunded', 'cancelled')),
-    ADD INDEX ix_order_user_id_status (user_id, status),
-    ADD INDEX ix_order_placed_at (placed_at);
+ALTER TABLE time_entry
+    ADD CONSTRAINT ck_time_entry__billable_amount_cents_nonneg
+        CHECK (billable_amount_cents >= 0),
+    ADD CONSTRAINT ux_time_entry__project_id_team_member_id_submitted_at
+        UNIQUE (project_id, team_member_id, submitted_at),
+    ADD INDEX ix_time_entry__project_id_submitted_at (project_id, submitted_at);
 ```
 
 ### Why the names matter
-- `ux_user_email` tells reviewers that the unique key protects email addresses. Without the prefix the intent would be hidden.
-- `ck_order_status` documents the allowed values in plain words. Debugging failed inserts becomes faster because MySQL includes the name in the error message.
-- Composite indexes like `ix_order_user_id_status` expose the column order so engineers can plan queries that match it.
 
-> **Field Note:** When a migration fails in production, a clear constraint name lets you find and fix the broken rule without guessing.
+- Check constraints describe the business rule being enforced.
+- The unique constraint spells out the natural key used for deduplication.
+- The index name reveals which query pattern it accelerates.
 
-## 9.3 Example View, Function, Trigger
-
-Naming rules help readers understand logic beyond tables. The following objects show how the prefixes from Chapter 6 apply in practice.
+## 9.3 Example view, function, and trigger
 
 ```sql
-CREATE OR REPLACE VIEW v_user_recent_orders AS
+CREATE OR REPLACE VIEW v_project_recent_activity AS
 SELECT
-    u.id AS user_id,
-    u.email,
-    o.public_id AS order_public_id,
-    o.total_amount_cents,
-    o.placed_at,
-    o.status
-FROM `user` u
-JOIN `order` o ON o.user_id = u.id
-WHERE o.placed_at >= NOW() - INTERVAL 30 DAY;
+    p.id AS project_id,
+    p.name,
+    te.team_member_id,
+    te.logged_minutes,
+    te.billable_amount_cents,
+    te.submitted_at
+FROM project p
+JOIN time_entry te ON te.project_id = p.id
+WHERE te.submitted_at >= NOW() - INTERVAL 30 DAY;
 ```
 
 ```sql
-DELIMITER $$
-CREATE FUNCTION fn_order_total_in_currency(p_order_id BIGINT UNSIGNED, p_currency_code CHAR(3))
-RETURNS DECIMAL(18, 2)
+DELIMITER //
+CREATE FUNCTION fn_project_logged_minutes(p_project_id BIGINT)
+RETURNS INT
 DETERMINISTIC
 BEGIN
-    DECLARE v_total_cents BIGINT;
-    DECLARE v_fraction SMALLINT;
-
-    SELECT total_amount_cents INTO v_total_cents
-    FROM `order`
-    WHERE id = p_order_id;
-
-    SELECT fraction INTO v_fraction
-    FROM currency
-    WHERE code = p_currency_code;
-
-    RETURN v_total_cents / POW(10, v_fraction);
-END$$
+    DECLARE v_total INT;
+    SELECT COALESCE(SUM(logged_minutes), 0) INTO v_total
+    FROM time_entry
+    WHERE project_id = p_project_id;
+    RETURN v_total;
+END //
 DELIMITER ;
 ```
 
 ```sql
-DELIMITER $$
-CREATE TRIGGER trg_order_set_fulfilled_at
-BEFORE UPDATE ON `order`
+DELIMITER //
+CREATE TRIGGER trg_project__after__update
+AFTER UPDATE ON project
 FOR EACH ROW
 BEGIN
-    IF NEW.status = 'paid' AND OLD.status <> 'paid' THEN
-        SET NEW.fulfilled_at = NOW();
+    IF NEW.is_active = 0 AND OLD.is_active = 1 THEN
+        INSERT INTO project_activity_log (project_id, action_code, occurred_at)
+        VALUES (NEW.id, 'archived', NOW());
     END IF;
-END$$
+END //
 DELIMITER ;
 ```
 
 ### Why the names matter
-- The `v_`, `fn_`, and `trg_` prefixes tell the reader what kind of object they are before reading the definition.
-- `fn_order_total_in_currency` describes inputs and behaviour. A vague name like `fn_convert` would leave the purpose unclear.
-- `trg_order_set_fulfilled_at` encodes both the target table and the action so maintainers can find it quickly.
 
-> **Field Note:** Clear routine names reduce onboarding time because new engineers can map business flows without reading every line of SQL.
+- Prefixes (`v_`, `fn_`, `trg_`) highlight the object type instantly.
+- Function and trigger names read like sentences, so reviewers know their purpose at a glance.
+- The trigger name records both timing and event, making it easy to spot in schema dumps.
 
-## 9.4 Example Migration File
+## 9.4 Example migration files
 
-Migrations are the final piece. A good filename and structure keep releases predictable.
-
-### File name pattern
+```text
+20240718120000_create-project-tables.sql
+20240718120500_add-time-entry-constraints.sql
+20240718121000_create-v_project_recent_activity.sql
 ```
-20240718-120000_add-order-totals.sql
-```
-- The timestamp sorts migrations chronologically.
-- Hyphen-separated words describe the action in plain language.
-- The verb-noun structure (`add-order-totals`) mirrors the change inside the file.
 
-### File contents
 ```sql
--- 20240718-120000_add-order-totals.sql
--- Adds total_amount_cents and fulfilled_at columns to order table.
-
-START TRANSACTION;
-
-ALTER TABLE `order`
-    ADD COLUMN total_amount_cents BIGINT UNSIGNED NOT NULL DEFAULT 0 AFTER currency_code,
-    ADD COLUMN fulfilled_at DATETIME NULL AFTER placed_at,
-    ADD INDEX ix_order_placed_at (placed_at);
-
-UPDATE `order`
-SET total_amount_cents = 0
-WHERE total_amount_cents IS NULL;
-
-COMMIT;
+-- 20240718120500_add-time-entry-constraints.sql
+-- Adds deduplication and non-negative checks to time_entry.
+-- Rollback: 20240718120500_add-time-entry-constraints_down.sql
+ALTER TABLE time_entry
+    ADD CONSTRAINT ck_time_entry__billable_amount_cents_nonneg
+        CHECK (billable_amount_cents >= 0),
+    ADD CONSTRAINT ux_time_entry__project_id_team_member_id_submitted_at
+        UNIQUE (project_id, team_member_id, submitted_at);
 ```
 
-### Why the structure works
-- A short comment at the top documents the intent for reviewers and incident responders.
-- Wrapping changes in a transaction makes the migration safe to rerun if a step fails.
-- Naming the index inside the migration keeps schema diffs clean when running `SHOW CREATE TABLE` later.
+### Why the names matter
 
-> **Field Note:** Teams that describe the change and index names directly in the migration file avoid the "mystery DDL" problem when reading production history.
+- Timestamps maintain order across environments.
+- Slugs summarise the intent without opening the file.
+- Rollback comments explain how to undo the change.
 
-[← Previous: Additional Conventions That Pay Off at Scale](08-additional-conventions.md) • [Back to index](index.md) • [Next chapter →](10-cheat-sheet.md)
+By following the same patterns in your own projects, you make the schema self-documenting and easier to maintain.

--- a/docs/10-cheat-sheet.md
+++ b/docs/10-cheat-sheet.md
@@ -2,69 +2,63 @@
 
 [← Previous: Examples & Patterns in Action](09-examples-and-patterns.md) • [Back to index](index.md) • [Next chapter →](11-conclusion.md)
 
-This quick reference condenses the full guide into a single page. Use it during code review, pair programming, or migration planning when you need fast reminders without rereading every chapter. Each section links the object type to the recommended pattern, explains the "why" in one sentence, and shows a safe example.
+Print this page or keep it open during reviews. Each line matches the detailed chapters but fits into a glanceable table.
 
-## 10.1 Database Names
+## 10.1 Database names
 
 | Do this | Why | Example |
 | --- | --- | --- |
-| Use lowercase snake case with product and context | Readers can guess ownership and purpose from the name alone | `billing_service_prod`
-| Keep environment suffixes short and predictable | Automation scripts can target the right database safely | `analytics_stg`
-| Avoid special characters or camelCase | Tools and shells behave consistently across platforms | `identity_dev`
+| `<product>_<purpose>_<env>` in lower_snake_case | Ownership and environment are obvious | `project_service_prod` |
+| Keep environment suffixes short (`dev`, `stg`, `prod`) | Scripts deploy to the right place | `analytics_stg` |
+| Avoid camelCase or hyphens | Works consistently across OS and tooling | `identity_archive` |
 
-> **Remember:** Database names change rarely. Choose clarity now to avoid risky renames later.
+## 10.2 Tables and columns
 
-## 10.2 Table Names
-
-| Rule | Why it helps | Example |
+| Rule | Reason | Example |
 | --- | --- | --- |
-| Use singular nouns (`order`, not `orders`) | Singular names avoid clashes with ORMs and make foreign keys obvious | `CREATE TABLE order (...);` |
-| Include descriptive nouns | People can read intent without guessing business meaning | `shipping_manifest`
-| Add suffixes only when they signal a pattern | Keeps names short while highlighting behaviour | `user_archive`, `tmp_daily_metrics`
+| Tables use singular nouns | Joins read naturally | `CREATE TABLE project (...);` |
+| Primary key column is `id` | Every foreign key points to the same name | `id BIGINT UNSIGNED PRIMARY KEY` |
+| Foreign keys end with `_id` | Relationships stay readable | `team_member_id BIGINT UNSIGNED` |
+| Timestamps end with `_at` | Signals a point in time | `submitted_at DATETIME NOT NULL` |
+| Soft deletes use `deleted_at` | `NULL` = active, value = archived | `deleted_at DATETIME NULL` |
+| Amounts include units | Prevents ambiguity | `billable_amount_cents` |
 
-## 10.3 Column Name Examples
+## 10.3 Constraints and indexes
 
-| Column type | Pattern | Reason |
-| --- | --- | --- |
-| Primary key | `id` | Every table shares the same join target |
-| Foreign key | `<referenced_table>_id` | Reveals the relationship at a glance |
-| Timestamp | `<action>_at` | Communicates that the value is a point in time |
-| Soft delete | `deleted_at` (`NULL` when active) | Queries can filter active rows simply |
-| Amounts | `<thing>_amount_<unit>` or `<thing>_<unit>` | Prevents confusion when multiple currencies or units exist |
-| JSON | `<topic>_json` | Signals a flexible payload and keeps structured columns clean |
-
-> **Tip:** Add column comments in migrations when the purpose is not obvious from the name alone.
-
-## 10.4 Constraint & Index Patterns
-
-| Type | Prefix | Example name | Notes |
+| Object | Prefix | Example name | Quick reminder |
 | --- | --- | --- | --- |
-| Primary key | `pk_` | `pk_order` | Usually auto-generated, but naming helps during schema reviews |
-| Foreign key | `fk_` | `fk_order_user` | Include both tables so you can spot relationships in error logs |
-| Unique constraint | `ux_` | `ux_user_email` | Highlight the business rule being protected |
-| Non-unique index | `ix_` | `ix_order_user_id_status` | Order columns from most to least selective |
-| Check constraint | `ck_` | `ck_order_status` | Describe the allowed values in words |
-| Full-text index | `ft_` | `ft_article_body` | Avoid mixing with non-text columns |
+| Primary key | `pk_` | `pk_time_entry` | Anchor for joins |
+| Foreign key | `fk_` | `fk_time_entry__project_id__project` | Include table, column, reference |
+| Unique constraint | `ux_` | `ux_project_member__project_id_team_member_id` | Shows protected business rule |
+| Non-unique index | `ix_` | `ix_time_entry__project_id_submitted_at` | Mirrors query order |
+| Check constraint | `ck_` | `ck_project__time_budget_minutes_nonneg` | Reads like a rule |
+| Full-text index | `ft_` | `ft_project_note__title_body` | Easy to find search indexes |
 
-## 10.5 Boolean & Enum Conventions
+## 10.4 Derived objects
 
-| Situation | Preferred pattern | Why |
+| Object type | Prefix pattern | Example |
 | --- | --- | --- |
-| Boolean columns | Prefix with `is_`, `has_`, or `can_` | Makes true/false intent explicit | 
-| Status codes | Use lookup tables or enums with meaning in the name | Prevents anonymous values like `status = 3` |
-| Feature flags | `is_feature_enabled` or `can_use_feature` | Clear to business and engineering readers |
-| Nullable booleans | Avoid when possible; use `NULL` only for "unknown" | Keeps logic simple and reduces three-state bugs |
+| View | `v_<purpose>` | `v_project_recent_activity` |
+| Stored procedure | `sp_<verb>_<object>` | `sp_archive_project` |
+| Function | `fn_<result>` | `fn_project_logged_minutes` |
+| Trigger | `trg_<table>__<timing>__<event>` | `trg_time_entry__before__insert` |
 
-## 10.6 Migration Filename Example
+## 10.5 Migrations
 
-```
-20240718-120000_add-user-preferred-currency.sql
-```
+| Guideline | Reminder |
+| --- | --- |
+| Filename starts with UTC timestamp | `20240718120000_add-project-status.sql` |
+| One change per file | Easier reviews and rollbacks |
+| Document rollback in comments or paired `_down` file | Saves time during incidents |
 
-- Timestamp (YYYYMMDD-HHMMSS) sorts files automatically.
-- Verb-noun description communicates the intent.
-- Hyphen-separated words stay readable on every operating system.
+## 10.6 Quick checklist before merging
 
-> **Field Note:** Agree on the filename pattern in your team charter so new engineers can contribute without asking for reminders.
+- [ ] Names use lower_snake_case and full words.
+- [ ] Reserved words are avoided or extended with qualifiers.
+- [ ] Booleans start with `is_` or `has_`.
+- [ ] Amount columns include units.
+- [ ] Timestamps use UTC and `_at` suffixes.
+- [ ] Constraints, indexes, and derived objects follow their prefixes.
+- [ ] Migration filenames start with a timestamp and describe one action.
 
-[← Previous: Examples & Patterns in Action](09-examples-and-patterns.md) • [Back to index](index.md) • [Next chapter →](11-conclusion.md)
+If every box is checked, your change aligns with the convention.

--- a/docs/11-conclusion.md
+++ b/docs/11-conclusion.md
@@ -2,34 +2,29 @@
 
 [← Previous: Cheat Sheet (Quick Reference)](10-cheat-sheet.md) • [Back to index](index.md)
 
-The final chapter explains why the naming standard works in the real world, how to enforce it without slowing teams down, and the guiding principle that keeps every exception honest.
+You now have a complete playbook for naming everything in MySQL. The final step is keeping the convention alive.
 
-## 11.1 Why These Conventions Work in Real-World Scale
+## 11.1 Why the convention works
 
-- **They reduce decision fatigue.** Engineers do not spend time inventing names on the spot because the pattern is already agreed. That speed matters when dozens of teams ship features at once.
-- **They keep automation reliable.** ETL pipelines, schema diff tools, and monitoring jobs expect predictable object names. When the schema stays consistent, automation scripts can be simple and resilient.
-- **They improve onboarding.** New hires can read the database like a well-written book. Each object tells a story through its name, so domain knowledge spreads faster.
-- **They make incidents calmer.** During an outage the right name points you to the right table or constraint immediately. Clear naming reduces the time spent searching and increases the time spent fixing.
+- **Less decision fatigue.** Engineers pick names from a menu instead of improvising.
+- **Reliable automation.** ETL, monitoring, and CI jobs depend on predictable patterns.
+- **Faster onboarding.** New teammates learn the schema in hours, not weeks.
+- **Calmer incidents.** During outages, the right name points straight to the right fix.
 
-> **Field Note:** Mature companies document naming rules because firefighting without a map is expensive and stressful.
+## 11.2 How to keep it enforced
 
-## 11.2 How to Enforce Them (Linters, CI/CD, Code Review)
+1. **Lint migrations.** Run tools such as `sqlfluff` or a lightweight regex checker in CI.
+2. **Diff the schema in reviews.** Export `SHOW CREATE TABLE` for new migrations and verify the prefixes.
+3. **Use review checklists.** Add items like “Are table names singular?” and “Do timestamps end with `_at`?” to pull requests.
+4. **Share examples.** Keep a folder of good migrations to copy and common mistakes to avoid.
+5. **Document exceptions.** When the business demands a deviation, log the reason, owner, and review date.
 
-1. **Add linting to migration pipelines.** Tools such as `sqlfluff` or custom scripts can reject files that break naming patterns before they reach version control.
-2. **Automate schema review.** Use CI jobs that run `SHOW CREATE TABLE` on new migrations and diff the output to confirm constraint and index names follow the prefixes.
-3. **Write review checklists.** Pull request templates should include reminders such as "Are table names singular?" and "Do new timestamps end with `_at`?".
-4. **Teach through examples.** Keep a shared folder of good migrations and bad anti-patterns so reviewers can point to concrete cases.
-5. **Document exceptions.** When a business rule requires a deviation, record the reason and the owner. That transparency prevents accidental spread of one-off patterns.
+## 11.3 Golden rule: consistency beats cleverness
 
-> **Tip:** Enforcing conventions works best when automation catches mistakes early and reviewers explain the "why" rather than only the "what".
+- Consistent names stay understandable for years.
+- Simple English helps analysts, engineers, and stakeholders collaborate.
+- A clear default makes legitimate exceptions stand out.
 
-## 11.3 The Golden Rule → Consistency Beats Cleverness
+> **Final reminder:** You can always defend a consistent name. You spend hours defending a clever one.
 
-- **Consistency keeps the schema teachable.** Clever names age poorly; consistent names stay readable for years.
-- **Consistency is inclusive.** Simple English and predictable patterns help cross-functional teammates participate in design discussions.
-- **Consistency scales.** When the schema follows one style, new services, analytics jobs, and data warehouses can integrate without friction.
-- **Consistency allows safe exceptions.** When the default is clear, an exception stands out and receives the scrutiny it deserves.
-
-> **Final Reminder:** You can always explain a consistent name. You spend hours explaining a clever one.
-
-[← Previous: Cheat Sheet (Quick Reference)](10-cheat-sheet.md) • [Back to index](index.md)
+Thanks for studying the guide—apply it to every migration and share it with your team.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,19 @@
 # MySQL Naming Conventions Guide · Index
 
-Welcome! This index mirrors the table of contents for the complete guide. Every chapter lives in its own Markdown file so you can focus on one topic at a time, similar to how W3Schools breaks lessons into short pages.
+Welcome! This guide is organised like a W3Schools tutorial: every lesson is short, practical, and linked right from this page. Open the chapters in order or jump directly to the topic you need.
 
-## Available Chapters
+## Browse the lessons
 
-- [Chapter 1 – Introduction](01-introduction.md)
-- [Chapter 2 – Core Naming Rules](02-core-naming-rules.md)
-- [Chapter 3 – Database-Level Conventions](03-database-level-conventions.md)
-- [Chapter 4 – Table & Column Naming](04-table-and-column-naming.md)
-- [Chapter 5 – Constraints & Indexes](05-constraints-and-indexes.md)
-- [Chapter 6 – Views, Routines & Triggers](06-views-routines-triggers.md)
-- [Chapter 7 – Migrations & Versioning](07-migrations-and-versioning.md)
-- [Chapter 8 – Additional Conventions That Pay Off at Scale](08-additional-conventions.md)
-- [Chapter 9 – Examples & Patterns in Action](09-examples-and-patterns.md)
-- [Chapter 10 – Cheat Sheet (Quick Reference)](10-cheat-sheet.md)
-- [Chapter 11 – Conclusion](11-conclusion.md)
+1. [Chapter 1 – Introduction](01-introduction.md) · Why predictable names save time and how to use this guide.
+2. [Chapter 2 – Core Naming Rules](02-core-naming-rules.md) · The everyday rules you will apply on every schema object.
+3. [Chapter 3 – Database-Level Conventions](03-database-level-conventions.md) · How to name databases, schemas, and shared resources.
+4. [Chapter 4 – Table & Column Naming](04-table-and-column-naming.md) · Step-by-step patterns for tables, columns, and keys.
+5. [Chapter 5 – Constraints & Indexes](05-constraints-and-indexes.md) · Friendly naming recipes for primary, foreign, check, and index objects.
+6. [Chapter 6 – Views, Routines & Triggers](06-views-routines-triggers.md) · Clear prefixes and examples for derived objects.
+7. [Chapter 7 – Migrations & Versioning](07-migrations-and-versioning.md) · File naming, sequencing, and rollback patterns.
+8. [Chapter 8 – Additional Conventions That Pay Off at Scale](08-additional-conventions.md) · Optional rules that become essential on larger teams.
+9. [Chapter 9 – Examples & Patterns in Action](09-examples-and-patterns.md) · A complete mini project that applies every rule.
+10. [Chapter 10 – Cheat Sheet (Quick Reference)](10-cheat-sheet.md) · Printable reminders for daily work.
+11. [Chapter 11 – Conclusion](11-conclusion.md) · How to keep the convention alive.
 
-All chapters from the original outline are now published. Share the guide with your team, link to specific chapters in code reviews, and suggest improvements through pull requests.
+Each chapter lives in its own Markdown file so you can link to it from reviews or onboarding docs. Happy learning!


### PR DESCRIPTION
## Summary
- rewrite every chapter of the naming guide in a W3Schools-style, step-by-step format for easier onboarding
- align examples around a consistent project-tracking schema and remove contradictory reserved-word usage in demonstrations
- refresh the cheat sheet, migration guidance, and index to match the updated conventions

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8e76cb2f4833287433c4e066bde3c